### PR TITLE
Add missing date field to charge create

### DIFF
--- a/src/api/charges.ts
+++ b/src/api/charges.ts
@@ -40,6 +40,7 @@ export interface ChargeCreateRequestInterface {
     title: string;
     description: string;
     tags: Array<TagInterface>;
+    dateTime: string|null;
 }
 
 export interface ChargeUpdateRequestInterface {
@@ -100,6 +101,7 @@ export function walletChargeCreate(walletId: number, request: ChargeCreateReques
         title: request.title,
         description: request.description,
         tags: request.tags.length ? request.tags.map(tag => tag.id) : null,
+        dateTime: request.dateTime,
     })
 }
 

--- a/src/components/wallets/ChargeEdit.vue
+++ b/src/components/wallets/ChargeEdit.vue
@@ -139,6 +139,7 @@
 <script lang="ts">
 import { Mixins, Component, Prop, Watch } from 'vue-property-decorator'
 import { AxiosResponse } from 'axios';
+import moment from 'moment';
 import Loader from '@/shared/Loader';
 import Messager from '@/shared/Messager';
 import Validator from '@/shared/Validator';
@@ -155,7 +156,6 @@ import WarningMessage from '@/components/shared/WarningMessage.vue';
 import TagFormInput from '@/components/tags/TagFormInput.vue';
 import Tag from '@/components/tags/Tag.vue';
 import ChargeTitleFormInput from '@/components/wallets/charges/ChargeTitleFormInput.vue';
-import moment from 'moment';
 
 export interface ChargeUpdatedEvent {
     id: string;

--- a/src/components/wallets/charges/ChargesList.vue
+++ b/src/components/wallets/charges/ChargesList.vue
@@ -284,9 +284,16 @@ export default class ChargesList extends Mixins(Loader) {
 
     // forward event
     protected onChargeCreated(event: ChargeCreatedEvent) {
-        this.charges.unshift(event.charge)
-        this.$root.$emit('bv::toggle::collapse', 'charge-create')
+        const charges = Array.from<ChargeInterface>(this.charges)
+        const index = charges.findIndex(charge => charge.dateTime < event.charge.dateTime)
 
+        if (index === -1) {
+            this.charges.unshift(event.charge)
+        } else {
+            this.charges.splice(index, 0, event.charge)
+        }
+
+        this.$root.$emit('bv::toggle::collapse', 'charge-create')
         this.$emit('created', event)
     }
 


### PR DESCRIPTION
When charge create form opened, there was no ability to set date in the same way as it was implemented in charge update form.