### PR TITLE
fix(frontend): post-migration UI and caching fixes

### DIFF
--- a/e2e/charges-create.spec.ts
+++ b/e2e/charges-create.spec.ts
@@ -384,4 +384,47 @@ test.describe('S8 — Charge Create', () => {
         }
     })
 
+    // CC-11 — ChargeTitleFormInput suggests tags by the titles of charges they were
+    // previously used on (GET /api/tags/suggestions/{query}, a `%query%` match on the
+    // charge title). Regression guard: the migration once wired this to the wallet
+    // tag-name prefix search (/wallets/{id}/tags/find), which never matches a typed
+    // title, so the title-input tag suggestions silently disappeared.
+    test('CC-11 title input suggests tags from matching charge titles', async ({ request, page }) => {
+        const w = await createWalletViaApi(request, { name: `E2E CC11 ${Date.now()}` })
+        const tagSeed = await createTagViaApi(request, { name: `E2Etag${Date.now()}` })
+        // A distinctive token in the seed charge title — what we'll type to match it.
+        const titleToken = `SuggestSeed${Date.now()}`
+        try {
+            // Seed a charge whose title contains the token AND carries the tag, so the
+            // tag becomes discoverable via the charge-title suggestion search.
+            await createChargeViaApi(request, w.id, {
+                title: `${titleToken} lunch`,
+                tags: [tagSeed.id],
+            })
+
+            await page.goto(`/wallets/${w.id}`)
+            await expect(page.getByRole('heading', { level: 2 })).toBeVisible({ timeout: 10000 })
+
+            await charge.newChargeButton(page).click()
+            await expect(charge.titleInput(page)).toBeVisible({ timeout: 5000 })
+
+            // Type the token — the title input fires the debounced autocomplete.
+            await charge.titleInput(page).fill(titleToken)
+
+            // The seeded tag must surface as an option inside the title input's listbox.
+            const titleTagOption = page.locator(`#charge-title-listbox #charge-title-option-tag-${tagSeed.id}`)
+            await expect(titleTagOption).toBeVisible({ timeout: 8000 })
+            await expect(titleTagOption).toContainText(tagSeed.name)
+
+            // Selecting it promotes the tag into the selected-tags row above the input.
+            await titleTagOption.click()
+            await expect(page.getByText(tagSeed.name).first()).toBeVisible({ timeout: 5000 })
+
+            await assertNoErrorLeak(page)
+        } finally {
+            await deleteTagViaApi(request, tagSeed.id)
+            await deleteWalletViaApi(request, w.id)
+        }
+    })
+
 })

--- a/nginx.conf
+++ b/nginx.conf
@@ -25,10 +25,46 @@ http {
         listen          80;
         server_name     localhost;
 
+        root        /usr/share/nginx/html;
+        index       index.html;
+
+        # Content-hashed build assets. Vite emits app chunks under /assets/ and
+        # vite-plugin-pwa emits the Workbox runtime as /workbox-<hash>.js at the
+        # root. Both carry a content hash in the filename, so the filename changes
+        # whenever the content does — safe to cache forever. immutable tells the
+        # browser never to revalidate; the long max-age lets Cloudflare hold them
+        # at the edge.
+        location /assets/ {
+            try_files   $uri =404;
+            add_header  Cache-Control "public, max-age=31536000, immutable";
+        }
+
+        location ~ ^/workbox-[0-9a-f]+\.js$ {
+            add_header  Cache-Control "public, max-age=31536000, immutable";
+        }
+
+        # The service worker, the runtime-config-bearing HTML shell and the PWA
+        # manifest must NEVER be cached by the browser or Cloudflare. A stale
+        # sw.js pins returning clients to an old bundle (this is what caused the
+        # /undefined redirect loop after deploys). no-store keeps Cloudflare from
+        # edge-caching them by file extension.
+        location = /sw.js {
+            add_header  Cache-Control "no-cache, no-store, must-revalidate";
+        }
+
+        location = /site.webmanifest {
+            add_header  Cache-Control "no-cache, no-store, must-revalidate";
+        }
+
+        location = /index.html {
+            add_header  Cache-Control "no-cache, no-store, must-revalidate";
+        }
+
+        # SPA fallback. Anything not matched above (routes, missing files) serves
+        # the HTML shell, which must also not be cached.
         location / {
-            root        /usr/share/nginx/html;
-            index       index.html;
             try_files   $uri $uri/ /index.html;
+            add_header  Cache-Control "no-cache, no-store, must-revalidate";
         }
 
         error_page   500 502 503 504  /50x.html;

--- a/src/App.vue
+++ b/src/App.vue
@@ -39,7 +39,13 @@ onMounted(() => profileStore.loadProfile())
 
 watch(loading, done => {
     if (!done && !isLogged.value) {
-        window.location.href = webSiteLink('/')
+        const websiteUrl = webSiteLink('/')
+        if (websiteUrl === '/' || websiteUrl === '') {
+            console.error('Unable to load website URL', window.__APP_CONFIG__)
+            setTimeout(() => window.location.reload(), 10000)
+            return
+        }
+        window.location.href = websiteUrl
     }
 })
 

--- a/src/api/__tests__/tags.spec.ts
+++ b/src/api/__tests__/tags.spec.ts
@@ -12,7 +12,7 @@ const mockAxios = { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() }
 
 import {
     getTags, createTag, updateTag, deleteTag,
-    getTagCharges, getTagTotals, getWalletTags, searchWalletTags,
+    getTagCharges, getTagTotals, getWalletTags, searchWalletTags, getTagSuggestions,
 } from '../tags'
 import { Tag } from '../models/tag'
 import { Charge, ChargeTotal } from '../models/charge'
@@ -155,6 +155,19 @@ describe('searchWalletTags', () => {
         const result = await searchWalletTags(2, 'foo bar')
 
         expect(mockAxios.get).toHaveBeenCalledWith('/api/wallets/2/tags/find/foo%20bar')
+        expect(result[0]).toBeInstanceOf(Tag)
+    })
+})
+
+describe('getTagSuggestions', () => {
+    beforeEach(() => vi.clearAllMocks())
+
+    it('calls GET /api/tags/suggestions/{query} with encoded query', async () => {
+        mockAxios.get = vi.fn().mockResolvedValue({ data: { data: [rawTag] } })
+
+        const result = await getTagSuggestions('foo bar')
+
+        expect(mockAxios.get).toHaveBeenCalledWith('/api/tags/suggestions/foo%20bar')
         expect(result[0]).toBeInstanceOf(Tag)
     })
 })

--- a/src/api/tags.ts
+++ b/src/api/tags.ts
@@ -100,3 +100,13 @@ export async function searchWalletTags(walletId: number, query: string): Promise
         return (res.data.data as unknown[]).map(Tag.from)
     })
 }
+
+// Charge-title autocomplete: matches tags by the titles of charges they were
+// previously used on (a `%query%` contains match), sorted by usage frequency.
+// This is distinct from searchWalletTags, which prefix-matches on the tag name.
+export async function getTagSuggestions(query: string): Promise<Tag[]> {
+    return apiCall(async client => {
+        const res = await client.get(`/api/tags/suggestions/${encodeURIComponent(query)}`)
+        return (res.data.data as unknown[]).map(Tag.from)
+    })
+}

--- a/src/components/wallets/charges/ChargeCreate.vue
+++ b/src/components/wallets/charges/ChargeCreate.vue
@@ -181,7 +181,6 @@ const formDate = computed<CalendarDate | null>({
                     ref="titleInputRef"
                     v-model="title"
                     :tags="selectedTags"
-                    :wallet-id="wallet.id"
                     :disabled="loading"
                     @tag-selected="onTagSelected"
                 />

--- a/src/components/wallets/charges/ChargeEdit.vue
+++ b/src/components/wallets/charges/ChargeEdit.vue
@@ -154,7 +154,6 @@ const formDate = computed<CalendarDate | null>({
                 <ChargeTitleFormInput
                     v-model="title"
                     :tags="selectedTags"
-                    :wallet-id="wallet.id"
                     :disabled="loading"
                     @tag-selected="onTagSelected"
                 />

--- a/src/components/wallets/charges/ChargeTitleFormInput.vue
+++ b/src/components/wallets/charges/ChargeTitleFormInput.vue
@@ -2,7 +2,7 @@
 import { ref, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { getChargeTitles } from '@/api/charges'
-import { searchWalletTags } from '@/api/tags'
+import { getTagSuggestions } from '@/api/tags'
 import type { Tag } from '@/api/models/tag'
 import type { ChargeTitleSuggestion } from '@/api/models/charge'
 import TagChip from '@/components/tags/Tag.vue'
@@ -10,7 +10,6 @@ import TagChip from '@/components/tags/Tag.vue'
 const props = defineProps<{
     modelValue: string
     tags: Tag[]
-    walletId: number
     disabled?: boolean
 }>()
 
@@ -99,7 +98,7 @@ function doAutocomplete(value: string) {
         debounceHandle.value = null
         const token = ++loadToken
         Promise.all([
-            searchWalletTags(props.walletId, q),
+            getTagSuggestions(q),
             getChargeTitles(q),
         ])
             .then(([tags, titles]) => {

--- a/src/components/wallets/charges/ChargesList.vue
+++ b/src/components/wallets/charges/ChargesList.vue
@@ -303,7 +303,7 @@ defineExpose({ onChargeCreated })
                         <UTooltip v-if="wallet.isActive" :text="t('charges.selectGroup')" :arrow="true">
                             <button
                                 type="button"
-                                class="size-6 rounded-full border transition-colors shrink-0 cursor-pointer flex items-center justify-center"
+                                class="size-6 rounded-full border transition-colors shrink-0 cursor-pointer flex items-center justify-center ml-2"
                                 :class="[
                                     isGroupSelected(groupCharges)
                                         ? 'bg-primary border-primary text-white'
@@ -318,7 +318,7 @@ defineExpose({ onChargeCreated })
                             </button>
                         </UTooltip>
                         <!-- Decorative divider for inactive wallets -->
-                        <div v-else class="w-6 shrink-0 h-px transition-colors bg-black/10 dark:bg-white/10" />
+                        <div v-else class="w-6 shrink-0 h-px transition-colors bg-black/10 dark:bg-white/10 ml-2" />
                         <span class="text-sm text-muted">{{ group }}</span>
                         <div class="flex-1 h-px transition-colors" :class="isGroupSelected(groupCharges) ? '' : 'bg-black/10 dark:bg-white/10'" />
                     </div>

--- a/src/components/wallets/charges/__tests__/ChargeCreate.spec.ts
+++ b/src/components/wallets/charges/__tests__/ChargeCreate.spec.ts
@@ -32,6 +32,7 @@ vi.mock('@/api/charges', () => ({
 vi.mock('@/api/tags', () => ({
     getWalletTags: vi.fn().mockResolvedValue([]),
     searchWalletTags: vi.fn().mockResolvedValue([]),
+    getTagSuggestions: vi.fn().mockResolvedValue([]),
 }))
 
 const usd = new Currency({

--- a/src/components/wallets/charges/__tests__/ChargeEdit.spec.ts
+++ b/src/components/wallets/charges/__tests__/ChargeEdit.spec.ts
@@ -31,6 +31,7 @@ vi.mock('@/api/charges', () => ({
 vi.mock('@/api/tags', () => ({
     getWalletTags: vi.fn().mockResolvedValue([]),
     searchWalletTags: vi.fn().mockResolvedValue([]),
+    getTagSuggestions: vi.fn().mockResolvedValue([]),
 }))
 
 const usd = new Currency({

--- a/src/components/wallets/charges/__tests__/ChargeTitleFormInput.spec.ts
+++ b/src/components/wallets/charges/__tests__/ChargeTitleFormInput.spec.ts
@@ -16,7 +16,7 @@ vi.mock('@/api/charges', () => ({
 }))
 
 vi.mock('@/api/tags', () => ({
-    searchWalletTags: vi.fn().mockResolvedValue([]),
+    getTagSuggestions: vi.fn().mockResolvedValue([]),
 }))
 
 describe('ChargeTitleFormInput', () => {
@@ -26,7 +26,7 @@ describe('ChargeTitleFormInput', () => {
 
     function mountInput(modelValue = '') {
         return shallowMount(ChargeTitleFormInput, {
-            props: { modelValue, tags: [], walletId: 1 },
+            props: { modelValue, tags: [] },
             global: {
                 stubs: {
                     // Render attrs on the stub root so we can assert them via html()
@@ -164,12 +164,12 @@ describe('ChargeTitleFormInput', () => {
             const newTitleData = [{ title: 'NewResult', count: 5 }]
 
             const { getChargeTitles } = await import('@/api/charges')
-            const { searchWalletTags } = await import('@/api/tags')
+            const { getTagSuggestions } = await import('@/api/tags')
             const mockGetChargeTitles = vi.mocked(getChargeTitles)
-            const mockSearchWalletTags = vi.mocked(searchWalletTags)
+            const mockGetTagSuggestions = vi.mocked(getTagSuggestions)
 
             // Both requests resolve tags immediately (empty); titles are deferred
-            mockSearchWalletTags.mockResolvedValue([])
+            mockGetTagSuggestions.mockResolvedValue([])
             mockGetChargeTitles
                 .mockImplementationOnce(() => new Promise(res => { resolveOldTitles = res }))
                 .mockImplementationOnce(() => new Promise(res => { resolveNewTitles = res }))
@@ -210,11 +210,11 @@ describe('ChargeTitleFormInput', () => {
             const staleTitleData = [{ title: 'Stale', count: 3 }]
 
             const { getChargeTitles } = await import('@/api/charges')
-            const { searchWalletTags } = await import('@/api/tags')
+            const { getTagSuggestions } = await import('@/api/tags')
             const mockGetChargeTitles = vi.mocked(getChargeTitles)
-            const mockSearchWalletTags = vi.mocked(searchWalletTags)
+            const mockGetTagSuggestions = vi.mocked(getTagSuggestions)
 
-            mockSearchWalletTags.mockResolvedValue([])
+            mockGetTagSuggestions.mockResolvedValue([])
             mockGetChargeTitles.mockImplementationOnce(
                 () => new Promise(res => { resolveInFlight = res }),
             )

--- a/src/components/wallets/limits/LimitForm.vue
+++ b/src/components/wallets/limits/LimitForm.vue
@@ -101,8 +101,10 @@ function onCancel() {
         </div>
 
         <!-- Tag search + Operation toggle + Amount -->
-        <div class="flex gap-2">
-            <UFormField class="w-3/5" :error="fieldErrors.tags?.[0]">
+        <!-- Mobile: stacked, full width (Type+Amount on top, Tag below). Desktop: one row,
+             Tag left (3/5) + Type+Amount right (2/5). flex order swaps the visual order. -->
+        <div class="flex flex-col sm:flex-row gap-2">
+            <UFormField class="w-full sm:w-3/5 order-2 sm:order-1" :error="fieldErrors.tags?.[0]">
                 <TagFormInput
                     ref="tagInputRef"
                     :wallet-id="wallet.id"
@@ -112,7 +114,7 @@ function onCancel() {
                 />
             </UFormField>
 
-            <div class="flex items-start gap-0 w-2/5">
+            <div class="flex items-start gap-0 w-full sm:w-2/5 order-1 sm:order-2">
                 <UButton
                     icon="i-lucide-arrow-down"
                     :variant="operation === '-' ? 'solid' : 'outline'"


### PR DESCRIPTION
Follow-up fixes on top of the merged Vue 3 + Nuxt UI migration.

## Changes

- **Charge-title tag autocomplete** — the title input was wired to the wallet tag-name *prefix* search (`/wallets/{id}/tags/find`) instead of the charge-title *suggestion* search (`/tags/suggestions`), so typing a title returned no tags. Adds `getTagSuggestions()` and rewires the input; drops the now-dead `walletId` prop.
- **App shell redirect** — when runtime config (`window.__APP_CONFIG__`) fails to load, `webSiteLink('/')` falls back to `'/'`; redirecting an unauthenticated user there loops on the same origin. Now detects the unresolved-config case and retries with a delayed reload.
- **nginx caching** — content-hashed `/assets/` and `workbox-<hash>.js` get `immutable` long-cache; `sw.js`, `index.html`, and `site.webmanifest` get `no-store`. Prevents a stale service worker from pinning returning clients to an old bundle (the `/undefined` redirect loop after deploys).
- **Mobile: charges list** — nudge the date-group select icon for correct alignment.
- **Mobile: limit form** — stack the amount/type and tag inputs full width (amount on top, tag below); desktop side-by-side layout unchanged via `sm:` + flex order.

## Coverage

Adds a CC-11 e2e regression test for the autocomplete fix plus unit-test updates. `npm run type-check`, `npm run lint` (0 errors), `npm run test:unit -- --run` (552 pass), and `npm run build` all green.