### PR TITLE
feat(frontend): surface distributed trace ID in error details

### DIFF
--- a/src/api/__tests__/client.spec.ts
+++ b/src/api/__tests__/client.spec.ts
@@ -281,17 +281,4 @@ describe('CsrfError', () => {
         const err = new CsrfError(new Error('x'))
         expect(err instanceof axios.AxiosError).toBe(false)
     })
-
-    it('stamps ctTraceId from the originating AxiosError response headers', () => {
-        const cause = Object.assign(new AxiosError('CSRF mismatch'), {
-            response: { status: 417, headers: { 'x-ct-trace-id': 'trace-417' } } as unknown as AxiosResponse,
-        })
-        const err = new CsrfError(cause)
-        expect(err.ctTraceId).toBe('trace-417')
-    })
-
-    it('leaves ctTraceId undefined when cause is a plain Error', () => {
-        const err = new CsrfError(new Error('cause'))
-        expect(err.ctTraceId).toBeUndefined()
-    })
 })

--- a/src/api/__tests__/client.spec.ts
+++ b/src/api/__tests__/client.spec.ts
@@ -18,6 +18,38 @@ function mockInstance(overrides: Partial<AxiosInstance> = {}): AxiosInstance {
     } as unknown as AxiosInstance
 }
 
+// AxiosInstance mock whose interceptors.response.use actually stores fulfilled
+// handlers, so a test can simulate a real response passing through them —
+// needed to exercise apiCall's trace-id-capturing interceptor.
+function mockInstanceWithInterceptors(overrides: Partial<AxiosInstance> = {}): {
+    instance: AxiosInstance
+    emitResponse: (response: AxiosResponse) => void
+} {
+    const fulfilledHandlers: Array<(response: AxiosResponse) => AxiosResponse> = []
+    const instance = {
+        get: vi.fn(),
+        post: vi.fn(),
+        put: vi.fn(),
+        delete: vi.fn(),
+        interceptors: {
+            request: { use: vi.fn() },
+            response: {
+                use: vi.fn((onFulfilled?: (response: AxiosResponse) => AxiosResponse) => {
+                    if (onFulfilled) fulfilledHandlers.push(onFulfilled)
+                }),
+            },
+        },
+        ...overrides,
+    } as unknown as AxiosInstance
+
+    return {
+        instance,
+        emitResponse: (response: AxiosResponse) => {
+            for (const handler of fulfilledHandlers) handler(response)
+        },
+    }
+}
+
 describe('apiCall', () => {
     let originalHref: string
     let originalReload: () => void
@@ -113,6 +145,29 @@ describe('apiCall', () => {
         ).rejects.toThrow('Forbidden')
 
         expect(fn).toHaveBeenCalledTimes(1)
+    })
+
+    it('attaches ctTraceId from error.response.headers for a non-CSRF AxiosError with a response', async () => {
+        const err = Object.assign(new AxiosError('Forbidden'), {
+            config: { method: 'POST' },
+            response: { status: 403, headers: { 'x-ct-trace-id': 'trace-403' } } as unknown as AxiosResponse,
+        })
+        const fn = vi.fn().mockRejectedValue(err)
+
+        const caught = await apiCall(fn, () => mockInstance()).catch((e: unknown) => e)
+        expect((caught as Record<string, unknown>).ctTraceId).toBe('trace-403')
+    })
+
+    it('attaches ctTraceId to a plain Error thrown after a successful response (model-parser case)', async () => {
+        const { instance, emitResponse } = mockInstanceWithInterceptors()
+        const fn = vi.fn().mockImplementation(async () => {
+            emitResponse({ headers: { 'x-ct-trace-id': 'trace-parser-1' } } as unknown as AxiosResponse)
+            throw new Error('User.from: expected object')
+        })
+
+        const caught = await apiCall(fn, () => instance).catch((e: unknown) => e)
+        expect(caught).toBeInstanceOf(Error)
+        expect((caught as Record<string, unknown>).ctTraceId).toBe('trace-parser-1')
     })
 })
 
@@ -225,5 +280,18 @@ describe('CsrfError', () => {
     it('is not an instance of AxiosError', () => {
         const err = new CsrfError(new Error('x'))
         expect(err instanceof axios.AxiosError).toBe(false)
+    })
+
+    it('stamps ctTraceId from the originating AxiosError response headers', () => {
+        const cause = Object.assign(new AxiosError('CSRF mismatch'), {
+            response: { status: 417, headers: { 'x-ct-trace-id': 'trace-417' } } as unknown as AxiosResponse,
+        })
+        const err = new CsrfError(cause)
+        expect(err.ctTraceId).toBe('trace-417')
+    })
+
+    it('leaves ctTraceId undefined when cause is a plain Error', () => {
+        const err = new CsrfError(new Error('cause'))
+        expect(err.ctTraceId).toBeUndefined()
     })
 })

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -18,15 +18,10 @@ function attachTraceId(error: unknown, traceId: string | undefined): void {
 }
 
 export class CsrfError extends Error {
-    ctTraceId?: string
-
     constructor(cause: Error) {
         super(cause.message)
         this.name = 'CsrfError'
         this.stack = cause.stack
-        if (cause instanceof AxiosError) {
-            this.ctTraceId = extractTraceId(cause.response?.headers)
-        }
     }
 }
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,11 +2,31 @@ import axios, { AxiosError, type AxiosInstance } from 'axios'
 import { webSiteLink } from '@/shared/links'
 import { getEnv } from '@/shared/env'
 
+// Axios normalizes response header lookups to lowercase regardless of wire casing.
+const TRACE_ID_HEADER = 'x-ct-trace-id'
+
+function extractTraceId(headers: unknown): string | undefined {
+    if (!headers || typeof headers !== 'object') return undefined
+    const value = (headers as Record<string, unknown>)[TRACE_ID_HEADER]
+    return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function attachTraceId(error: unknown, traceId: string | undefined): void {
+    if (traceId && error && typeof error === 'object') {
+        Object.assign(error, { ctTraceId: traceId })
+    }
+}
+
 export class CsrfError extends Error {
+    ctTraceId?: string
+
     constructor(cause: Error) {
         super(cause.message)
         this.name = 'CsrfError'
         this.stack = cause.stack
+        if (cause instanceof AxiosError) {
+            this.ctTraceId = extractTraceId(cause.response?.headers)
+        }
     }
 }
 
@@ -100,38 +120,56 @@ export async function apiCall<T>(
 ): Promise<T> {
     const instance = instanceFactory()
 
-    return withTransportRetry(async () => {
-        try {
-            return await fn(instance)
-        } catch (error) {
-            // Do not attempt CSRF retry for safe methods
-            if (
-                error instanceof AxiosError &&
-                ['GET', 'OPTIONS'].includes(error.config?.method?.toUpperCase() ?? '')
-            ) {
-                return Promise.reject(error)
-            }
-
-            if (!(error instanceof CsrfError)) {
-                return Promise.reject(error)
-            }
-
-            // Attempt CSRF token refresh then retry
-            let refreshed: boolean
-            try {
-                refreshed = await refreshCsrfToken(instance)
-            } catch (refreshError) {
-                window.location.reload()
-                return Promise.reject(refreshError)
-            }
-
-            if (refreshed) {
-                return fn(instance)
-            }
-
-            // Refresh returned false (401) — auth expired
-            window.location.href = webSiteLink('/login')
-            return Promise.reject(new Error('CSRF refresh failed — redirecting to login'))
-        }
+    // Remembers the trace ID of the last successful response on this call, so it's
+    // still available if a later step (e.g. response shape parsing) throws a plain
+    // Error with no AxiosResponse attached.
+    const lastResponseTraceId: { value?: string } = {}
+    instance.interceptors.response.use((response) => {
+        lastResponseTraceId.value = extractTraceId(response.headers) ?? lastResponseTraceId.value
+        return response
     })
+
+    try {
+        return await withTransportRetry(async () => {
+            try {
+                return await fn(instance)
+            } catch (error) {
+                // Do not attempt CSRF retry for safe methods
+                if (
+                    error instanceof AxiosError &&
+                    ['GET', 'OPTIONS'].includes(error.config?.method?.toUpperCase() ?? '')
+                ) {
+                    return Promise.reject(error)
+                }
+
+                if (!(error instanceof CsrfError)) {
+                    return Promise.reject(error)
+                }
+
+                // Attempt CSRF token refresh then retry
+                let refreshed: boolean
+                try {
+                    refreshed = await refreshCsrfToken(instance)
+                } catch (refreshError) {
+                    window.location.reload()
+                    return Promise.reject(refreshError)
+                }
+
+                if (refreshed) {
+                    return fn(instance)
+                }
+
+                // Refresh returned false (401) — auth expired
+                window.location.href = webSiteLink('/login')
+                return Promise.reject(new Error('CSRF refresh failed — redirecting to login'))
+            }
+        })
+    } catch (error) {
+        const traceId =
+            error instanceof AxiosError && error.response
+                ? extractTraceId(error.response.headers)
+                : lastResponseTraceId.value
+        attachTraceId(error, traceId)
+        throw error
+    }
 }

--- a/src/shared/__tests__/errors.spec.ts
+++ b/src/shared/__tests__/errors.spec.ts
@@ -52,4 +52,30 @@ describe('describeError', () => {
         const result = describeError(null)
         expect(result).toContain('null')
     })
+
+    it('includes traceId line when ctTraceId is present on an AxiosError', () => {
+        const err = makeHttpAxiosError(500)
+        Object.assign(err, { ctTraceId: 'abc123trace' })
+        const result = describeError(err)
+        expect(result).toContain('traceId=abc123trace')
+    })
+
+    it('omits traceId line when ctTraceId is absent on an AxiosError', () => {
+        const err = makeHttpAxiosError(500)
+        const result = describeError(err)
+        expect(result).not.toContain('traceId=')
+    })
+
+    it('includes traceId line when ctTraceId is present on a plain Error', () => {
+        const err = new Error('parser failed')
+        Object.assign(err, { ctTraceId: 'def456trace' })
+        const result = describeError(err)
+        expect(result).toContain('traceId=def456trace')
+    })
+
+    it('omits traceId line when ctTraceId is absent on a plain Error', () => {
+        const err = new Error('parser failed')
+        const result = describeError(err)
+        expect(result).not.toContain('traceId=')
+    })
 })

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -6,15 +6,22 @@ import { AxiosError } from 'axios'
  */
 export function describeError(error: unknown): string {
     const at = new Date().toISOString()
+    const rawTraceId = (error as Record<string, unknown> | null)?.ctTraceId
+    const traceLine = typeof rawTraceId === 'string' && rawTraceId.length > 0 ? `traceId=${rawTraceId}` : null
+
     if (error instanceof AxiosError) {
         const parts = [
             error.response ? `HTTP ${error.response.status}` : 'No response (network/timeout)',
             error.code ? `code=${error.code}` : null,
             error.config?.method ? `${error.config.method.toUpperCase()} ${error.config.url ?? ''}`.trim() : null,
             error.message ? `msg=${error.message}` : null,
+            traceLine,
         ].filter(Boolean)
         return `${at}\n${parts.join('\n')}`
     }
-    if (error instanceof Error) return `${at}\n${error.name}: ${error.message}`
+    if (error instanceof Error) {
+        const parts = [`${error.name}: ${error.message}`, traceLine].filter(Boolean)
+        return `${at}\n${parts.join('\n')}`
+    }
     return `${at}\n${String(error)}`
 }


### PR DESCRIPTION
## Summary
- Capture the gateway's `X-Ct-Trace-Id` response header in `apiCall()`, covering both direct HTTP error responses and the case where a request succeeds (200) but the response body fails shape validation afterward (e.g. `User.from: expected object`) — the trace ID is remembered from a response interceptor before the parser throws.
- Append a `traceId=` line to `describeError()`'s output so it shows up in `LoadErrorAlert`'s "Show details" text, letting a user/support report be matched to the corresponding gateway/API trace.
- Companion change to `cash-track/gateway` (separate PR) exposes the header via CORS so browser JS can actually read it.