### PR TITLE
fix(charges): close actions dropdown when charge edit form closes

### DIFF
--- a/e2e/charges-edit-delete.spec.ts
+++ b/e2e/charges-edit-delete.spec.ts
@@ -159,6 +159,12 @@ test.describe('S12 — Charge Edit + Delete', () => {
             // Edit form should close
             await expect(editForm(page)).not.toBeVisible({ timeout: 5000 })
 
+            // Regression guard (frontend#105): the row's "..." actions dropdown must
+            // also be closed after Save, not just the edit form.
+            await expect(
+                page.getByRole('menuitem', { name: new RegExp(labelStrings('charges.edit').join('|'), 'i') }),
+            ).toBeHidden({ timeout: 5000 })
+
             await assertNoErrorLeak(page)
         } finally {
             await deleteWalletViaApi(request, w.id)
@@ -192,6 +198,12 @@ test.describe('S12 — Charge Edit + Delete', () => {
 
             // Edit form should close
             await expect(editForm(page)).not.toBeVisible({ timeout: 5000 })
+
+            // Regression guard (frontend#105): the row's "..." actions dropdown must
+            // also be closed after Cancel, not just the edit form.
+            await expect(
+                page.getByRole('menuitem', { name: new RegExp(labelStrings('charges.edit').join('|'), 'i') }),
+            ).toBeHidden({ timeout: 5000 })
 
             // Original charge title still visible
             await expect(page.getByText(c.title)).toBeVisible()

--- a/src/components/wallets/charges/ChargeItem.vue
+++ b/src/components/wallets/charges/ChargeItem.vue
@@ -55,16 +55,19 @@ function toggleExpand() {
 function startEdit() {
     isEdit.value = true
     isExpanded.value = false
+    isDropdownOpen.value = false
 }
 
 function cancelEdit() {
     isEdit.value = false
     isExpanded.value = false
+    isDropdownOpen.value = false
 }
 
 function onUpdated(charge: Charge) {
     isEdit.value = false
     isExpanded.value = false
+    isDropdownOpen.value = false
     emit('updated', charge)
 }
 

--- a/src/components/wallets/charges/__tests__/ChargeItem.spec.ts
+++ b/src/components/wallets/charges/__tests__/ChargeItem.spec.ts
@@ -490,4 +490,78 @@ describe('ChargeItem', () => {
         expect(ukResult).toBe(expectedUk)
         expect(ukResult).not.toBe(enResult)
     })
+
+    it('closes the dropdown when the Edit action is selected (startEdit)', async () => {
+        const authStore = useAuthStore()
+        authStore.isEmailConfirmed = true
+
+        const charge = makeCharge({})
+        const wrapper = shallowMount(ChargeItem, {
+            props: { charge, wallet: makeWallet() },
+        })
+
+        const vm = wrapper.vm as unknown as {
+            isDropdownOpen: boolean
+            isEdit: boolean
+            actionItems: Array<Array<{ label: string; onSelect?: () => void }>>
+        }
+        // The user necessarily had the dropdown open to click "Edit"
+        vm.isDropdownOpen = true
+        await nextTick()
+
+        const editItem = vm.actionItems.flat().find(item => item.label === 'charges.edit')
+        expect(editItem?.onSelect).toBeDefined()
+        editItem!.onSelect!()
+        await nextTick()
+
+        expect(vm.isEdit).toBe(true)
+        expect(vm.isDropdownOpen).toBe(false)
+    })
+
+    it('keeps the dropdown closed after cancelling the edit form (cancelEdit)', async () => {
+        const charge = makeCharge({})
+        const wrapper = shallowMount(ChargeItem, {
+            props: { charge, wallet: makeWallet() },
+        })
+
+        const vm = wrapper.vm as unknown as {
+            isDropdownOpen: boolean
+            isEdit: boolean
+            cancelEdit: () => void
+        }
+        // Simulate edit mode having been entered while the dropdown's open flag was stale
+        vm.isEdit = true
+        vm.isDropdownOpen = true
+        await nextTick()
+
+        vm.cancelEdit()
+        await nextTick()
+
+        expect(vm.isEdit).toBe(false)
+        expect(vm.isDropdownOpen).toBe(false)
+    })
+
+    it('keeps the dropdown closed after a successful save (onUpdated)', async () => {
+        const charge = makeCharge({})
+        const wrapper = shallowMount(ChargeItem, {
+            props: { charge, wallet: makeWallet() },
+        })
+
+        const vm = wrapper.vm as unknown as {
+            isDropdownOpen: boolean
+            isEdit: boolean
+            onUpdated: (charge: Charge) => void
+        }
+        vm.isEdit = true
+        vm.isDropdownOpen = true
+        await nextTick()
+
+        vm.onUpdated(charge)
+        await nextTick()
+
+        expect(vm.isEdit).toBe(false)
+        expect(vm.isDropdownOpen).toBe(false)
+        expect(wrapper.emitted('updated')).toBeTruthy()
+        expect(wrapper.emitted('updated')![0]).toEqual([charge])
+    })
 })


### PR DESCRIPTION
## Problem statement

Fixes #105. Editing a Charge from the wallet's charge list via the row's "..." actions dropdown → Edit closed the edit form correctly on Save, but the dropdown itself stayed open (or reopened) afterward. Same issue on Cancel.

## Changes

`isDropdownOpen` (bound to `UDropdownMenu`'s `v-model:open`) was never reset when entering/leaving edit mode. The dropdown's DOM lives inside `v-if="!isEdit"`, so it unmounts while editing and remounts once editing ends — but the stale `true` ref caused the freshly remounted dropdown to render already-open.

Reset `isDropdownOpen.value = false` in `startEdit()`, `cancelEdit()`, and `onUpdated()` in `src/components/wallets/charges/ChargeItem.vue`.

## Verification

- Independent review pass: no material findings.
- Unit tests: added 3 tests covering the Edit-select, Cancel, and Save paths in `ChargeItem.spec.ts`; full suite green (78 files / 602 tests).
- E2E: extended existing cases CE-02/CE-03 in `charges-edit-delete.spec.ts` with regression-guard assertions that the dropdown is closed after Save/Cancel; targeted run green (8/8) against the live dev stack.
- Manual browser verification against the live stack: confirmed the dropdown stays closed after both Save and Cancel, no visual regressions.