### PR TITLE
fix(wallets): scroll and cap Copy From wallets list in limits panel

### DIFF
--- a/src/components/wallets/limits/WalletLimitsTotal.vue
+++ b/src/components/wallets/limits/WalletLimitsTotal.vue
@@ -22,6 +22,8 @@ const showCreateForm = ref(false)
 const walletsWithLimits = ref<Wallet[]>([])
 const copyLoading = ref(false)
 
+const MAX_COPY_FROM_WALLETS = 10
+
 const totalExpenseAmount = computed(() =>
     limits.value
         .filter(wl => wl.limit.operation === '-')
@@ -49,7 +51,10 @@ async function loadWalletsWithLimits() {
         if (wallets.length === 0) {
             wallets = await getWalletsWithLimits(true)
         }
-        walletsWithLimits.value = wallets.filter(w => w.id !== props.wallet.id)
+        walletsWithLimits.value = wallets
+            .filter(w => w.id !== props.wallet.id)
+            .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+            .slice(0, MAX_COPY_FROM_WALLETS)
     } catch {
         // Non-fatal; just don't show the button
     }
@@ -163,6 +168,7 @@ defineExpose({ reload: loadLimits, copyDropdownItems })
                 <UDropdownMenu
                     v-if="!limits.length && walletsWithLimits.length"
                     :items="copyDropdownItems"
+                    :ui="{ content: 'max-h-60' }"
                     arrow size="md"
                 >
                     <UButton

--- a/src/components/wallets/limits/__tests__/WalletLimitsTotal.spec.ts
+++ b/src/components/wallets/limits/__tests__/WalletLimitsTotal.spec.ts
@@ -30,14 +30,14 @@ import { getWalletsWithLimits } from '@/api/wallets'
 
 const usd = new Currency({ id: 'USD', code: 'USD', name: 'US Dollar', char: '$', rate: 1, updatedAt: new Date() })
 
-function makeWallet(id = 1, name = 'Test Wallet'): Wallet {
+function makeWallet(id = 1, name = 'Test Wallet', createdAt = new Date()): Wallet {
     return new Wallet({
         id, name,
         slug: name.toLowerCase().replace(/ /g, '-'),
         totalAmount: 1000,
         isActive: true, isPublic: false, isArchived: false,
         defaultCurrencyCode: 'USD', defaultCurrency: usd,
-        createdAt: new Date(), updatedAt: new Date(),
+        createdAt, updatedAt: new Date(),
         users: [], latestCharges: [],
     })
 }
@@ -156,5 +156,34 @@ describe('WalletLimitsTotal', () => {
         mountComponent()
         await flushPromises()
         expect(vi.mocked(getWalletsWithLimits)).not.toHaveBeenCalled()
+    })
+
+    it('caps the Copy From list at 10 wallets when more qualify', async () => {
+        const current = makeWallet(1, 'Current')
+        const others = Array.from({ length: 15 }, (_, i) =>
+            makeWallet(i + 2, `Wallet ${i + 2}`, new Date(2020, 0, i + 1)),
+        )
+        vi.mocked(getLimits).mockResolvedValue([])
+        vi.mocked(getWalletsWithLimits).mockResolvedValue(others)
+        const wrapper = mountComponent(current)
+        await flushPromises()
+        expect(getCopyItems(wrapper)).toHaveLength(10)
+    })
+
+    it('keeps only the 10 newest wallets by createdAt, newest first', async () => {
+        const current = makeWallet(1, 'Current')
+        const others = Array.from({ length: 15 }, (_, i) =>
+            makeWallet(i + 2, `Wallet ${i + 2}`, new Date(2020, 0, i + 1)),
+        )
+        vi.mocked(getLimits).mockResolvedValue([])
+        vi.mocked(getWalletsWithLimits).mockResolvedValue(others)
+        const wrapper = mountComponent(current)
+        await flushPromises()
+        const labels = getCopyItems(wrapper).map(item => item.label)
+        // Wallets 2..16 created on Jan 1..15, 2020 — newest is "Wallet 16" (Jan 15), oldest kept is "Wallet 7" (Jan 6).
+        expect(labels).toEqual([
+            'Wallet 16', 'Wallet 15', 'Wallet 14', 'Wallet 13', 'Wallet 12',
+            'Wallet 11', 'Wallet 10', 'Wallet 9', 'Wallet 8', 'Wallet 7',
+        ])
     })
 })


### PR DESCRIPTION
## Problem statement

Closes #113. The "Copy From" dropdown in the wallet Limits panel (used to copy limits from another wallet) had no scrollbar — the Nuxt UI dropdown content had no max-height, so a long wallet list overflowed off-screen instead of scrolling. Also folded in a related request: cap the offered list to the 10 most recently created wallets.

## Changes

- `WalletLimitsTotal.vue`: added `:ui="{ content: 'max-h-60' }"` to the Copy From `UDropdownMenu` so the list is height-bounded and its existing `overflow-y-auto` viewport actually engages, matching the scrollable-list convention already used in `ChargeTitleFormInput.vue`.
- Same file: the wallets offered to copy from are now sorted by `createdAt` descending and capped to the 10 newest (after excluding the current wallet).
- Added unit test coverage for the 10-item cap and newest-first ordering.

## Verification

- Independent review: no material findings (checked sort/mutation safety, the archived-fallback fetch path, Nuxt UI prop correctness, test determinism, i18n impact).
- Full unit suite: 604/604 passing, no regressions.
- Full production build: clean.
- E2E (`wallet-limits.spec.ts`, S19): 6/6 passing.
- Browser verification against the dev stack: Copy From dropdown opens correctly, `max-h-60` confirmed live in the DOM, no layout regression in light or dark mode. The dev account only has 4 wallets with limits, so the 10-item cap/sort itself is covered by the new unit tests rather than a live visual check.