### PR TITLE
fix(frontend): display unknown-field validation errors in generic alert

### DIFF
--- a/e2e/wallet-create.spec.ts
+++ b/e2e/wallet-create.spec.ts
@@ -151,6 +151,28 @@ test.describe('S3 — Wallet Create', () => {
         // skipped because the "unknown error" string is the expected output of a 500.
     })
 
+    // WC-08 — 422 error for a field the form doesn't render surfaces via the
+    // generic alert (generalError), instead of silently vanishing.
+    test('WC-08 422 error for unrendered field shows in general alert', async ({ page }) => {
+        // Navigate first, let currencies load, THEN install route intercept
+        await page.goto('/wallets/create')
+        await expect(wallet.formName(page)).toBeVisible({ timeout: 10000 })
+        await wallet.formName(page).fill('Slug Collision Wallet')
+        await waitForCreateEnabled(page)
+
+        // 'slug' has no bound UFormField in WalletCreate — this must land in the
+        // generic alert (generalError), not get dropped in an unrendered fieldErrors entry.
+        await route422(page, '**/api/wallets', { slug: ['Slug is already taken'] }, 'POST')
+
+        await wallet.formCreate(page).click()
+
+        await expect(page.getByText(/Slug is already taken/i)).toBeVisible({ timeout: 5000 })
+
+        // Still on create page — no redirect
+        await expect(page).toHaveURL(/\/wallets\/create/)
+        await assertNoErrorLeak(page)
+    })
+
     // WC-06 — Cancel link navigates back to /wallets
     test('WC-06 Cancel link goes back to /wallets', async ({ page }) => {
         await page.goto('/wallets/create')

--- a/src/components/settings/ProfileSettings.vue
+++ b/src/components/settings/ProfileSettings.vue
@@ -14,7 +14,12 @@ import EmailFormInput from '@/components/settings/EmailFormInput.vue'
 const { t } = useI18n()
 const profileStore = useProfileStore()
 const { profile } = storeToRefs(profileStore)
-const { fieldErrors, generalError, handleError, reset } = useApiErrors()
+const { fieldErrors, generalError, handleError, reset } = useApiErrors([
+    'name',
+    'lastName',
+    'nickName',
+    'defaultCurrencyCode',
+])
 
 const form = reactive({
     name: '',

--- a/src/components/settings/SecuritySettings.vue
+++ b/src/components/settings/SecuritySettings.vue
@@ -5,7 +5,11 @@ import { updatePassword } from '@/api/profile/password'
 import { useApiErrors } from '@/composables/useApiErrors'
 
 const { t } = useI18n()
-const { fieldErrors, generalError, handleError, reset } = useApiErrors()
+const { fieldErrors, generalError, handleError, reset } = useApiErrors([
+    'currentPassword',
+    'newPassword',
+    'newPasswordConfirmation',
+])
 
 const form = reactive({
     currentPassword: '',

--- a/src/components/tags/TagForm.vue
+++ b/src/components/tags/TagForm.vue
@@ -17,7 +17,10 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
-const { fieldErrors, generalError, reset: resetErrors, handleError } = useApiErrors()
+const { fieldErrors, generalError, reset: resetErrors, handleError } = useApiErrors([
+    'name',
+    'icon',
+])
 
 const nameInput = ref('')
 const color = ref('#6366f1')

--- a/src/components/wallets/WalletCreate.vue
+++ b/src/components/wallets/WalletCreate.vue
@@ -13,7 +13,10 @@ const { t } = useI18n()
 const router = useRouter()
 const profileStore = useProfileStore()
 const walletsStore = useWalletsStore()
-const { fieldErrors, generalError, handleError, reset } = useApiErrors()
+const { fieldErrors, generalError, handleError, reset } = useApiErrors([
+    'name',
+    'defaultCurrencyCode',
+])
 
 const form = reactive({
     name: '',

--- a/src/components/wallets/WalletEdit.vue
+++ b/src/components/wallets/WalletEdit.vue
@@ -15,7 +15,10 @@ const props = defineProps<{ wallet: Wallet }>()
 const { t } = useI18n()
 const router = useRouter()
 const walletsStore = useWalletsStore()
-const { fieldErrors, generalError, handleError, reset } = useApiErrors()
+const { fieldErrors, generalError, handleError, reset } = useApiErrors([
+    'name',
+    'defaultCurrencyCode',
+])
 
 const form = reactive({
     name: props.wallet.name,

--- a/src/components/wallets/WalletShare.vue
+++ b/src/components/wallets/WalletShare.vue
@@ -14,7 +14,7 @@ const props = defineProps<{ wallet: Wallet }>()
 
 const { t } = useI18n()
 const router = useRouter()
-const { fieldErrors, handleError, reset } = useApiErrors()
+const { fieldErrors, handleError, reset } = useApiErrors(['email'])
 const { notifyError } = useNotifications()
 
 const members = shallowRef<User[]>([])

--- a/src/components/wallets/__tests__/WalletCreate.spec.ts
+++ b/src/components/wallets/__tests__/WalletCreate.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
+import { AxiosError } from 'axios'
 import WalletCreate from '../WalletCreate.vue'
 
 const { mockCreateWallet, mockLoadActive, mockRouterPush } = vi.hoisted(() => ({
@@ -195,5 +196,69 @@ describe('WalletCreate', () => {
         // if we call onSubmit directly with empty name and no currency it won't have been called
         // because the button is disabled — here we verify the API was not called when name is blank
         expect(mockCreateWallet).not.toHaveBeenCalled()
+    })
+
+    it('routes a 422 error for a field the form does not render into generalError', async () => {
+        const axiosError = new AxiosError('Validation failed')
+        axiosError.response = {
+            status: 422,
+            data: { errors: { slug: ['Slug is already taken'] } },
+            headers: {},
+            config: {} as never,
+            statusText: 'Unprocessable Entity',
+        }
+        mockCreateWallet.mockRejectedValue(axiosError)
+
+        const wrapper = mount(WalletCreate, globalStubs)
+        const vm = wrapper.vm as unknown as {
+            form: { name: string; defaultCurrencyCode: string }
+            onSubmit: () => Promise<void>
+            fieldErrors: Record<string, string[]>
+            generalError: string | null
+        }
+        vm.form.name = 'Test Wallet'
+        vm.form.defaultCurrencyCode = 'USD'
+        await wrapper.vm.$nextTick()
+
+        await vm.onSubmit()
+
+        // 'slug' has no bound UFormField in this form — it must not vanish into an
+        // unrendered fieldErrors entry, it must surface via the generic alert instead.
+        expect(vm.fieldErrors.slug).toBeUndefined()
+        expect(vm.generalError).toBe('Slug is already taken')
+    })
+
+    it('keeps a mixed known+unknown 422 split between fieldErrors and generalError', async () => {
+        const axiosError = new AxiosError('Validation failed')
+        axiosError.response = {
+            status: 422,
+            data: {
+                errors: {
+                    name: ['Name is required'],
+                    slug: ['Slug is already taken'],
+                },
+            },
+            headers: {},
+            config: {} as never,
+            statusText: 'Unprocessable Entity',
+        }
+        mockCreateWallet.mockRejectedValue(axiosError)
+
+        const wrapper = mount(WalletCreate, globalStubs)
+        const vm = wrapper.vm as unknown as {
+            form: { name: string; defaultCurrencyCode: string }
+            onSubmit: () => Promise<void>
+            fieldErrors: Record<string, string[]>
+            generalError: string | null
+        }
+        vm.form.name = 'Test Wallet'
+        vm.form.defaultCurrencyCode = 'USD'
+        await wrapper.vm.$nextTick()
+
+        await vm.onSubmit()
+
+        expect(vm.fieldErrors.name?.[0]).toBe('Name is required')
+        expect(vm.fieldErrors.slug).toBeUndefined()
+        expect(vm.generalError).toBe('Slug is already taken')
     })
 })

--- a/src/components/wallets/charges/ChargeCreate.vue
+++ b/src/components/wallets/charges/ChargeCreate.vue
@@ -24,7 +24,14 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
-const { fieldErrors, generalError, reset: resetErrors, handleError } = useApiErrors()
+const { fieldErrors, generalError, reset: resetErrors, handleError } = useApiErrors([
+    'amount',
+    'type',
+    'title',
+    'tags',
+    'description',
+    'dateTime',
+])
 const authStore = useAuthStore()
 
 const titleInputRef = ref<InstanceType<typeof ChargeTitleFormInput> | null>(null)

--- a/src/components/wallets/charges/ChargeEdit.vue
+++ b/src/components/wallets/charges/ChargeEdit.vue
@@ -24,7 +24,14 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
-const { fieldErrors, generalError, reset: resetErrors, handleError } = useApiErrors()
+const { fieldErrors, generalError, reset: resetErrors, handleError } = useApiErrors([
+    'amount',
+    'type',
+    'title',
+    'tags',
+    'description',
+    'dateTime',
+])
 const authStore = useAuthStore()
 
 const loading = ref(false)

--- a/src/components/wallets/limits/LimitForm.vue
+++ b/src/components/wallets/limits/LimitForm.vue
@@ -21,7 +21,11 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
-const { fieldErrors, generalError, reset: resetErrors, handleError } = useApiErrors()
+const { fieldErrors, generalError, reset: resetErrors, handleError } = useApiErrors([
+    'tags',
+    'amount',
+    'type',
+])
 
 const tagInputRef = ref<InstanceType<typeof TagFormInput> | null>(null)
 const loading = ref(false)

--- a/src/composables/__tests__/useApiErrors.spec.ts
+++ b/src/composables/__tests__/useApiErrors.spec.ts
@@ -171,4 +171,119 @@ describe('useApiErrors', () => {
         expect(generalError.value).toBe('unknownError')
         expect(consoleSpy).toHaveBeenCalled()
     })
+
+    describe('known/unknown field split (knownFields option)', () => {
+        it('without knownFields, behaves exactly like the legacy full-fieldErrors mode', () => {
+            const { fieldErrors, generalError, handleError } = useApiErrors()
+
+            handleError(makeAxiosError(422, {
+                errors: { name: ['Required'], somethingNotRendered: ['Unexpected'] },
+            }))
+
+            expect(fieldErrors.value).toEqual({
+                name: ['Required'],
+                somethingNotRendered: ['Unexpected'],
+            })
+            expect(generalError.value).toBeNull()
+        })
+
+        it('all errors for known fields populate fieldErrors only, generalError stays null', () => {
+            const { fieldErrors, generalError, handleError } = useApiErrors(['name', 'email'])
+
+            handleError(makeAxiosError(422, {
+                errors: { name: ['Required'], email: ['Invalid'] },
+            }))
+
+            expect(fieldErrors.value).toEqual({ name: ['Required'], email: ['Invalid'] })
+            expect(generalError.value).toBeNull()
+        })
+
+        it('errors for a field the form does not render go to generalError, not fieldErrors', () => {
+            const { fieldErrors, generalError, handleError } = useApiErrors(['name'])
+
+            handleError(makeAxiosError(422, {
+                errors: { slug: ['Slug is already taken'] },
+            }))
+
+            expect(fieldErrors.value).toEqual({})
+            expect(generalError.value).toBe('Slug is already taken')
+        })
+
+        it('joins multiple unknown-field messages into generalError', () => {
+            const { generalError, handleError } = useApiErrors(['name'])
+
+            handleError(makeAxiosError(422, {
+                errors: {
+                    slug: ['Slug is already taken'],
+                    isPublic: ['Must be a boolean'],
+                },
+            }))
+
+            expect(generalError.value).toBe('Slug is already taken Must be a boolean')
+        })
+
+        it('joins multiple messages for a single unknown field into generalError', () => {
+            const { generalError, handleError } = useApiErrors(['name'])
+
+            handleError(makeAxiosError(422, {
+                errors: { slug: ['Too short', 'Already taken'] },
+            }))
+
+            expect(generalError.value).toBe('Too short Already taken')
+        })
+
+        it('mixed known+unknown: known field -> fieldErrors, unknown field -> generalError', () => {
+            const { fieldErrors, generalError, handleError } = useApiErrors(['name'])
+
+            handleError(makeAxiosError(422, {
+                errors: {
+                    name: ['Name is required'],
+                    slug: ['Slug is already taken'],
+                },
+            }))
+
+            expect(fieldErrors.value).toEqual({ name: ['Name is required'] })
+            expect(fieldErrors.value.slug).toBeUndefined()
+            expect(generalError.value).toBe('Slug is already taken')
+        })
+
+        it('empty errors object still yields the legacy t("validationError") regardless of knownFields', () => {
+            const { fieldErrors, generalError, handleError } = useApiErrors(['name'])
+
+            handleError(makeAxiosError(422, { errors: {} }))
+
+            expect(fieldErrors.value).toEqual({})
+            expect(generalError.value).toBe('validationError')
+        })
+
+        it('unparseable 422 body still yields t("validationError") regardless of knownFields', () => {
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+            const { generalError, handleError } = useApiErrors(['name'])
+
+            handleError(makeAxiosError(422, null))
+
+            expect(generalError.value).toBe('validationError')
+            expect(consoleSpy).toHaveBeenCalled()
+        })
+
+        it('non-422 / non-HTTP behaviour is unaffected by knownFields', () => {
+            const { generalError, handleError } = useApiErrors(['name'])
+
+            handleError(new Error('Network failure'))
+
+            expect(generalError.value).toBe('unknownError')
+        })
+
+        it('reset() clears both fieldErrors and a knownFields-derived generalError', () => {
+            const { fieldErrors, generalError, handleError, reset } = useApiErrors(['name'])
+
+            handleError(makeAxiosError(422, { errors: { slug: ['Slug is already taken'] } }))
+            expect(generalError.value).toBe('Slug is already taken')
+
+            reset()
+
+            expect(fieldErrors.value).toEqual({})
+            expect(generalError.value).toBeNull()
+        })
+    })
 })

--- a/src/composables/useApiErrors.ts
+++ b/src/composables/useApiErrors.ts
@@ -3,7 +3,16 @@ import { AxiosError } from 'axios'
 import { ApiError, ValidationError } from '@/api/models/error'
 import i18n from '@/lang'
 
-export function useApiErrors() {
+/**
+ * @param knownFields Names of fields the calling form actually renders (i.e. has a
+ * `UFormField :error` bound to). When provided, 422 errors for any other key are not
+ * dropped — they're joined into `generalError` so they still reach the user via the
+ * form's `UAlert`, instead of silently landing in an unrendered `fieldErrors` entry.
+ * Omit it (or leave undefined) to keep the legacy behaviour of putting every 422 key
+ * straight into `fieldErrors`.
+ */
+export function useApiErrors(knownFields?: string[]) {
+    const knownFieldSet = knownFields ? new Set(knownFields) : null
     const fieldErrors = ref<Record<string, string[]>>({})
     const generalError = ref<string | null>(null)
 
@@ -26,9 +35,25 @@ export function useApiErrors() {
         if (status === 422) {
             try {
                 const ve = ValidationError.from(data)
-                fieldErrors.value = ve.errors
+
                 if (Object.keys(ve.errors).length === 0) {
                     generalError.value = i18n.global.t('validationError')
+                } else if (knownFieldSet) {
+                    const known: Record<string, string[]> = {}
+                    const unknownMessages: string[] = []
+                    for (const [field, messages] of Object.entries(ve.errors)) {
+                        if (knownFieldSet.has(field)) {
+                            known[field] = messages
+                        } else {
+                            unknownMessages.push(...messages)
+                        }
+                    }
+                    fieldErrors.value = known
+                    if (unknownMessages.length > 0) {
+                        generalError.value = unknownMessages.join(' ')
+                    }
+                } else {
+                    fieldErrors.value = ve.errors
                 }
             } catch (parseError) {
                 console.error('[useApiErrors] HTTP error', 422, parseError)


### PR DESCRIPTION
## Problem

Some forms receive 422 validation errors containing fields that are not part of the form. `useApiErrors` put every error into `fieldErrors`, so keys with no bound input were silently dropped, leaving the UI in an unknown state with no feedback.

Closes #117

## Changes

- `useApiErrors` accepts an optional `knownFields` list. Errors for known fields keep the existing per-field behaviour; messages for fields the form does not render are joined into `generalError`, which every form already displays in its alert. Omitting the parameter preserves the legacy behaviour.
- All nine consumer forms (wallet create/edit/share, charge create/edit, tag form, limit form, profile and security settings) declare their actual template-bound field sets, verified against their `:error="fieldErrors.X"` bindings.
- The empty-errors, unparseable-422, and non-422 paths are unchanged.

## Verification

- Independent code review: no material findings; every `knownFields` set re-verified against template bindings and every call site checked.
- `npm run type-check` clean, `npm run lint` 0 errors, full Vitest suite green (620 tests), including 10 new composable tests covering the known/unknown split and preserved legacy paths, plus 2 new WalletCreate integration tests.
- New Playwright case WC-08 mocks a 422 with an unrendered field and asserts the message appears in the generic alert; full E2E suite passed against the local stack.