### PR TITLE
feat(frontend): add error details and retry actions to error alerts

### DIFF
--- a/e2e/charges-create.spec.ts
+++ b/e2e/charges-create.spec.ts
@@ -303,9 +303,9 @@ test.describe('S8 — Charge Create', () => {
             await charge.titleInput(page).fill('test error')
             await charge.createButton(page).click()
 
-            // generalError alert via UAlert description slot
+            // generalError is non-422 → ChargeCreate renders LoadErrorAlert via :title
             await expect(
-                page.locator('[data-slot="description"]').first(),
+                page.locator('[data-slot="title"]').first(),
             ).toBeVisible({ timeout: 5000 })
             // intentional error test — no assertNoErrorLeak
         } finally {

--- a/e2e/charges-list.spec.ts
+++ b/e2e/charges-list.spec.ts
@@ -18,9 +18,9 @@ const chargesLoadingOverlay = (page: import('@playwright/test').Page) =>
 const chargesEmpty = (page: import('@playwright/test').Page) =>
     page.getByText(new RegExp(labelStrings('charges.empty').join('|'), 'i'))
 
-// Error alert (UAlert has no role=alert — match by description text)
+// Error alert — LoadErrorAlert has no role=alert and renders the message via :title
 const chargesLoadingErrorAlert = (page: import('@playwright/test').Page) =>
-    page.locator('[data-slot="description"]').filter({
+    page.locator('[data-slot="title"]').filter({
         hasText: new RegExp(labelStrings('charges.loadingError').join('|'), 'i'),
     })
 
@@ -28,9 +28,9 @@ const chargesLoadingErrorAlert = (page: import('@playwright/test').Page) =>
 const todayHeader = (page: import('@playwright/test').Page) =>
     page.getByText(new RegExp(labelStrings('charges.today').join('|'), 'i')).first()
 
-// Retry button
+// Retry button (LoadErrorAlert renders it via common.retry)
 const retryBtn = (page: import('@playwright/test').Page) =>
-    page.getByRole('button', { name: label('retry') })
+    page.getByRole('button', { name: label('common.retry') })
 
 // Charge row item (by title text). ChargeItem root is 'group flex items-stretch';
 // this distinguishes it from the day-group header which is 'group px-0 sm:px-4 ...'.

--- a/e2e/error-states.spec.ts
+++ b/e2e/error-states.spec.ts
@@ -14,17 +14,13 @@ import {
 
 // ── Local selectors ───────────────────────────────────────────────────────────
 
-// UAlert rendered via :description (no role=alert in Nuxt UI — match data-slot="description")
-const alertDescription = (page: import('@playwright/test').Page, text: RegExp) =>
-    page.locator('[data-slot="description"]').filter({ hasText: text }).first()
-
 // Generic text match (for alerts rendered with :title — WalletsActiveGridList uses :title)
 const alertTitle = (page: import('@playwright/test').Page, text: RegExp) =>
     page.locator('[data-slot="title"]').filter({ hasText: text }).first()
 
-// Retry button (retry key)
+// Retry button (LoadErrorAlert renders it via common.retry)
 const retryBtn = (page: import('@playwright/test').Page) =>
-    page.getByRole('button', { name: label('retry') })
+    page.getByRole('button', { name: label('common.retry') })
 
 // Nav shell still intact check
 const navShellVisible = async (page: import('@playwright/test').Page) => {
@@ -77,8 +73,8 @@ test.describe('S20 — Error States', () => {
             await page.goto(`/wallets/${w.id}`)
 
             const errorText = new RegExp(labelStrings('wallets.loadingError').join('|'), 'i')
-            // WalletView renders UAlert with :description="error" when load fails
-            await expect(alertDescription(page, errorText)).toBeVisible({ timeout: 10000 })
+            // WalletView renders LoadErrorAlert with :title="error" when load fails
+            await expect(alertTitle(page, errorText)).toBeVisible({ timeout: 10000 })
 
             await navShellVisible(page)
         } finally {
@@ -109,7 +105,8 @@ test.describe('S20 — Error States', () => {
             await expect(page.getByRole('heading', { level: 2 })).toBeVisible({ timeout: 10000 })
 
             const errorText = new RegExp(labelStrings('charges.loadingError').join('|'), 'i')
-            await expect(alertDescription(page, errorText)).toBeVisible({ timeout: 10000 })
+            // ChargesList renders LoadErrorAlert with :title="error"
+            await expect(alertTitle(page, errorText)).toBeVisible({ timeout: 10000 })
 
             // Retry button must be present
             await expect(retryBtn(page)).toBeVisible()
@@ -127,8 +124,8 @@ test.describe('S20 — Error States', () => {
         await page.goto('/tags')
 
         const errorText = new RegExp(labelStrings('tags.statsLoadingError').join('|'), 'i')
-        // TagsView renders UAlert with :description="error"
-        await expect(alertDescription(page, errorText)).toBeVisible({ timeout: 10000 })
+        // TagsView renders LoadErrorAlert with :title="error"
+        await expect(alertTitle(page, errorText)).toBeVisible({ timeout: 10000 })
 
         // Retry button
         await expect(retryBtn(page)).toBeVisible()

--- a/e2e/settings-profile.spec.ts
+++ b/e2e/settings-profile.spec.ts
@@ -14,9 +14,9 @@ const profileSuccessAlert = (page: import('@playwright/test').Page) =>
     page.locator('[data-slot="description"]')
         .filter({ hasText: new RegExp(labelStrings('profileSettings.success').join('|'), 'i') })
 
-// Alert: general error
+// Alert: general error — non-422 general errors render via LoadErrorAlert's :title
 const generalErrorAlert = (page: import('@playwright/test').Page) =>
-    page.locator('[data-slot="description"]')
+    page.locator('[data-slot="title"]')
         .filter({ hasText: /error|помилка/i })
 
 // Social section error text (profileSettings.socialLoadError — plain text, not alert)

--- a/e2e/settings-security.spec.ts
+++ b/e2e/settings-security.spec.ts
@@ -39,9 +39,9 @@ const mismatchError = (page: import('@playwright/test').Page) =>
         new RegExp(labelStrings('securitySettings.newPasswordConfirmationDescription').join('|'), 'i'),
     ).first()
 
-// General error alert (rendered by UAlert with generalError)
+// General error alert — non-422 general errors render via LoadErrorAlert's :title
 const generalErrorAlert = (page: import('@playwright/test').Page) =>
-    page.locator('[data-slot="description"]')
+    page.locator('[data-slot="title"]')
         .filter({ hasText: /error|помилка/i })
 
 // Passkey name input (passkeySettings.keyName placeholder)

--- a/e2e/support/selectors.ts
+++ b/e2e/support/selectors.ts
@@ -67,7 +67,7 @@ export const charge = {
     titleInput: (page: Page): Locator => page.getByPlaceholder(label('charges.title')).first(),
     createButton: (page: Page): Locator =>
         page.getByRole('button', { name: labelExact('charges.create') }),
-    retryButton: (page: Page): Locator => page.getByRole('button', { name: label('retry') }),
+    retryButton: (page: Page): Locator => page.getByRole('button', { name: label('common.retry') }),
     // Row actions are hover-revealed on desktop — caller must row.hover() first.
     rowActions: (row: Locator): Locator =>
         row.getByRole('button', { name: label('wallets.moreActions') }),

--- a/e2e/tag-detail.spec.ts
+++ b/e2e/tag-detail.spec.ts
@@ -392,7 +392,10 @@ test.describe('S10 — Tag Detail', () => {
             // UAlert is not role="alert" — match by text
             await expect(chargesLoadErrorText(page)).toBeVisible({ timeout: 10000 })
 
-            const retryBtn = page.getByRole('button', { name: label('retry') })
+            // Route glob also matches TagChargesFlowChart's /charges/graph endpoint, so both
+            // it and the charges list show their own LoadErrorAlert + retry button — use
+            // .first() since we only assert that at least one retry action is present.
+            const retryBtn = page.getByRole('button', { name: label('common.retry') }).first()
             await expect(retryBtn).toBeVisible()
 
             await assertNoErrorLeak(page)

--- a/e2e/tags-list.spec.ts
+++ b/e2e/tags-list.spec.ts
@@ -81,8 +81,12 @@ test.describe('S9 — Tags List', () => {
 
         await expect(tagsErrorText(page)).toBeVisible({ timeout: 10000 })
 
-        const retryBtn = page.getByRole('button', { name: label('retry') })
+        // Both actions must be present on a GET-load failure: Retry AND Show details
+        const retryBtn = page.getByRole('button', { name: label('common.retry') })
         await expect(retryBtn).toBeVisible()
+        await expect(
+            page.getByRole('button', { name: label('common.showDetails') }),
+        ).toBeVisible()
 
         // Clicking retry should refetch and show the page (or the list / empty state)
         await retryBtn.click()
@@ -211,6 +215,47 @@ test.describe('S9 — Tags List', () => {
         // Field error should appear (rendered by UFormField :error)
         await expect(page.getByText(/Name already taken/i)).toBeVisible({ timeout: 8000 })
         await assertNoErrorLeak(page)
+    })
+
+    // TG-08b — Server 500 (non-422) on POST /api/tags → TagForm renders LoadErrorAlert:
+    // "Show details" toggle present, no Retry button (form submissions are never retryable).
+    // Intentional error test — skip assertNoErrorLeak
+    test('TG-08b server 500 on create shows Show details and no Retry', async ({ page }) => {
+        // Method-filtered: only the create POST fails — the initial GET /api/tags list
+        // load must still succeed so the CreateTag/TagForm UI actually renders.
+        await page.route('**/api/tags', route => {
+            if (route.request().method() === 'POST') {
+                return route.fulfill({
+                    status: 500,
+                    contentType: 'application/json',
+                    body: '{"message":"E2E forced error"}',
+                })
+            }
+            return route.continue()
+        })
+
+        await page.goto('/tags')
+        await expect(tag.nameInput(page)).toBeVisible({ timeout: 10000 })
+
+        await tag.nameInput(page).fill('abc')
+        await expect(tag.createButton(page)).toBeEnabled({ timeout: 5000 })
+        await tag.createButton(page).click()
+
+        // General (non-422) error → LoadErrorAlert, message rendered via :title
+        await expect(
+            page.locator('[data-slot="title"]').filter({ hasText: /error|помилка/i }).first(),
+        ).toBeVisible({ timeout: 8000 })
+
+        // Show details toggle must be present
+        const showDetailsBtn = page.getByRole('button', { name: label('common.showDetails') })
+        await expect(showDetailsBtn).toBeVisible()
+
+        // Retry must NOT be present — this is a mutating submission, not a load
+        await expect(page.getByRole('button', { name: label('common.retry') })).toHaveCount(0)
+
+        // Clicking Show details reveals the raw error text
+        await showDetailsBtn.click()
+        await expect(page.getByRole('button', { name: label('common.hideDetails') })).toBeVisible()
     })
 
     // TG-09 — Chip → Popover → View navigates to /tags/{id} @smoke

--- a/e2e/wallet-edit.spec.ts
+++ b/e2e/wallet-edit.spec.ts
@@ -116,10 +116,9 @@ test.describe('S4 — Wallet Edit', () => {
 
             await wallet.formUpdate(page).click()
 
-            // UAlert has no role="alert"; it renders as div[data-slot="root"]
-            // The generalError description appears in [data-slot="description"]
+            // 500 is non-422 → WalletEdit renders LoadErrorAlert via :title (not :description)
             await expect(
-                page.locator('[data-slot="description"]').first(),
+                page.locator('[data-slot="title"]').first(),
             ).toBeVisible({ timeout: 5000 })
             await expect(page).toHaveURL(new RegExp(`/wallets/${seeded.id}/edit`))
             // Skip assertNoErrorLeak — 500 intentionally surfaces the unknown-error text
@@ -219,13 +218,13 @@ test.describe('S4 — Wallet Edit', () => {
 
             await overlay.confirmDelete(page).click()
 
-            // After error: modal closes, generalError displayed in the form (div[data-slot="description"])
+            // After error: modal closes, generalError displayed in the form via LoadErrorAlert
             // Also: dialog should close
             await expect(overlay.dialog(page)).not.toBeVisible({ timeout: 5000 })
 
-            // General error alert appears — UAlert renders description in [data-slot="description"]
+            // General error alert appears — 500 is non-422 → renders via :title
             await expect(
-                page.locator('[data-slot="description"]').first(),
+                page.locator('[data-slot="title"]').first(),
             ).toBeVisible({ timeout: 5000 })
 
             // Form is still on the edit page (stays usable)

--- a/e2e/wallet-share.spec.ts
+++ b/e2e/wallet-share.spec.ts
@@ -38,9 +38,10 @@ const inviteBtn = (page: import('@playwright/test').Page) =>
 const searchError = (page: import('@playwright/test').Page) =>
     page.getByText(new RegExp(labelStrings('wallets.shareSearchError').join('|'), 'i')).first()
 
-// Invite error toast
-const inviteErrorToast = (page: import('@playwright/test').Page) =>
-    page.getByRole('alert').filter({
+// Invite error — non-422 general error, rendered by LoadErrorAlert via :title (no toast:
+// WalletShare shows a single specific inline message rather than a duplicate toast)
+const inviteErrorAlert = (page: import('@playwright/test').Page) =>
+    page.locator('[data-slot="title"]').filter({
         hasText: new RegExp(labelStrings('wallets.shareInviteError').join('|'), 'i'),
     }).first()
 
@@ -234,8 +235,12 @@ test.describe('S7 — Wallet Share', () => {
         }
     })
 
-    // SH-07 — Invite error → notifyError shareInviteError toast
-    test('SH-07 invite API error shows shareInviteError notification', async ({ request, page }) => {
+    // SH-07 — Invite error (non-422) → single specific inline LoadErrorAlert: Show details,
+    // no Retry (mutating action). No toast — the inline alert is the sole error surface.
+    test('SH-07 invite API error shows a specific alert with Show details and no Retry', async ({
+        request,
+        page,
+    }) => {
         const w = await createWalletViaApi(request, { name: `E2E SH07 ${Date.now()}` })
         try {
             const foundUser = mockUser(8004, 'Error User SH07')
@@ -263,8 +268,22 @@ test.describe('S7 — Wallet Share', () => {
             await expect(inviteBtn(page)).toBeVisible({ timeout: 5000 })
             await inviteBtn(page).click()
 
-            // Expect the invite error notification
-            await expect(inviteErrorToast(page)).toBeVisible({ timeout: 10000 })
+            // The specific invite-error message appears in the inline alert (never the
+            // generic "Unknown error" fallback, so assertNoErrorLeak stays meaningful below)
+            await expect(inviteErrorAlert(page)).toBeVisible({ timeout: 10000 })
+
+            // Show details toggle present and functional
+            const showDetailsBtn = page.getByRole('button', { name: label('common.showDetails') })
+            await expect(showDetailsBtn).toBeVisible()
+            await showDetailsBtn.click()
+            await expect(
+                page.getByRole('button', { name: label('common.hideDetails') }),
+            ).toBeVisible()
+
+            // No Retry — inviting is a mutating action, never retryable
+            await expect(
+                page.getByRole('button', { name: label('common.retry') }),
+            ).toHaveCount(0)
 
             await assertNoErrorLeak(page)
         } finally {

--- a/src/App.vue
+++ b/src/App.vue
@@ -61,6 +61,7 @@ watch(locale, () => setDocumentTitle(router.currentRoute.value))
                     v-else-if="failed"
                     :title="t('profile.loadError')"
                     :error="lastError"
+                    retryable
                     @retry="profileStore.loadProfile()"
                 />
             </UContainer>

--- a/src/components/Shared/LoadErrorAlert.vue
+++ b/src/components/Shared/LoadErrorAlert.vue
@@ -3,7 +3,9 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { describeError } from '@/shared/errors'
 
-const props = defineProps<{ title: string; error: unknown }>()
+const props = withDefaults(defineProps<{ title: string; error: unknown; retryable?: boolean }>(), {
+    retryable: false,
+})
 const emit = defineEmits<{ retry: [] }>()
 
 const { t } = useI18n()
@@ -15,6 +17,20 @@ function onRetry() {
     emit('retry')
 }
 
+const actions = computed(() => {
+    const list = []
+    if (props.retryable) {
+        list.push({ label: t('common.retry'), color: 'error' as const, variant: 'solid' as const, onClick: onRetry })
+    }
+    list.push({
+        label: showDetails.value ? t('common.hideDetails') : t('common.showDetails'),
+        color: 'error' as const,
+        variant: 'outline' as const,
+        onClick: () => { showDetails.value = !showDetails.value },
+    })
+    return list
+})
+
 defineExpose({ showDetails })
 </script>
 
@@ -24,10 +40,7 @@ defineExpose({ showDetails })
         variant="soft"
         icon="i-lucide-triangle-alert"
         :title="title"
-        :actions="[
-            { label: t('common.retry'), color: 'error', variant: 'solid', onClick: onRetry },
-            { label: showDetails ? t('common.hideDetails') : t('common.showDetails'), color: 'error', variant: 'outline', onClick: () => (showDetails = !showDetails) },
-        ]"
+        :actions="actions"
     >
         <template v-if="showDetails" #description>
             <pre

--- a/src/components/Shared/__tests__/LoadErrorAlert.spec.ts
+++ b/src/components/Shared/__tests__/LoadErrorAlert.spec.ts
@@ -28,11 +28,12 @@ const alertStub = {
     `,
 }
 
-function mountComponent(props: { title?: string; error?: unknown } = {}) {
+function mountComponent(props: { title?: string; error?: unknown; retryable?: boolean } = {}) {
     return mount(LoadErrorAlert, {
         props: {
             title: props.title ?? 'Test title',
             error: props.error ?? null,
+            ...(props.retryable !== undefined ? { retryable: props.retryable } : {}),
         },
         global: {
             plugins: [createPinia()],
@@ -54,14 +55,38 @@ describe('LoadErrorAlert', () => {
         expect(wrapper.text()).toContain('wallets.listLoadingError')
     })
 
-    it('shows common.retry and common.showDetails action labels', () => {
-        const wrapper = mountComponent()
+    it('shows common.retry and common.showDetails action labels when retryable', () => {
+        const wrapper = mountComponent({ retryable: true })
         expect(wrapper.text()).toContain('common.retry')
         expect(wrapper.text()).toContain('common.showDetails')
     })
 
+    it('does not show common.retry when retryable is omitted (defaults false)', () => {
+        const wrapper = mountComponent()
+        expect(wrapper.text()).not.toContain('common.retry')
+        expect(wrapper.text()).toContain('common.showDetails')
+    })
+
+    it('does not show common.retry when retryable is explicitly false', () => {
+        const wrapper = mountComponent({ retryable: false })
+        expect(wrapper.text()).not.toContain('common.retry')
+        expect(wrapper.text()).toContain('common.showDetails')
+    })
+
+    it('never emits retry and has no retry button when not retryable', async () => {
+        const wrapper = mountComponent({ error: new Error('fail'), retryable: false })
+        const retryBtn = wrapper.findAll('button.u-alert-action').find(b => b.text() === 'common.retry')
+        expect(retryBtn).toBeUndefined()
+
+        // Show Details still works normally with retryable off.
+        const detailsBtn = wrapper.findAll('button.u-alert-action').find(b => b.text() === 'common.showDetails')
+        await detailsBtn!.trigger('click')
+        expect(wrapper.find('pre').exists()).toBe(true)
+        expect(wrapper.emitted('retry')).toBeUndefined()
+    })
+
     it('emits retry and resets showDetails when Try Again is clicked', async () => {
-        const wrapper = mountComponent({ error: new Error('fail') })
+        const wrapper = mountComponent({ error: new Error('fail'), retryable: true })
 
         // open details first
         const detailsBtn = wrapper.findAll('button.u-alert-action').find(b => b.text() === 'common.showDetails')

--- a/src/components/profile/LatestWallets.vue
+++ b/src/components/profile/LatestWallets.vue
@@ -44,6 +44,7 @@ onMounted(load)
             :title="t('wallets.listLoadingError')"
             :error="lastError"
             class="mb-4"
+            retryable
             @retry="load()"
         />
 

--- a/src/components/settings/ProfileSettings.vue
+++ b/src/components/settings/ProfileSettings.vue
@@ -10,11 +10,12 @@ import { locales } from '@/lang'
 import type { Currency } from '@/api/models/currency'
 
 import EmailFormInput from '@/components/settings/EmailFormInput.vue'
+import LoadErrorAlert from '@/components/Shared/LoadErrorAlert.vue'
 
 const { t } = useI18n()
 const profileStore = useProfileStore()
 const { profile } = storeToRefs(profileStore)
-const { fieldErrors, generalError, handleError, reset } = useApiErrors([
+const { fieldErrors, generalError, generalErrorRaw, handleError, reset } = useApiErrors([
     'name',
     'lastName',
     'nickName',
@@ -204,8 +205,9 @@ async function onSubmit() {
                 />
             </UFormField>
 
+            <LoadErrorAlert v-if="generalErrorRaw" :title="generalError ?? t('unknownError')" :error="generalErrorRaw" />
             <UAlert
-                v-if="generalError"
+                v-else-if="generalError"
                 color="error"
                 :description="generalError"
                 icon="i-lucide-alert-circle"

--- a/src/components/settings/SecuritySettings.vue
+++ b/src/components/settings/SecuritySettings.vue
@@ -3,9 +3,10 @@ import { reactive, shallowRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { updatePassword } from '@/api/profile/password'
 import { useApiErrors } from '@/composables/useApiErrors'
+import LoadErrorAlert from '@/components/Shared/LoadErrorAlert.vue'
 
 const { t } = useI18n()
-const { fieldErrors, generalError, handleError, reset } = useApiErrors([
+const { fieldErrors, generalError, generalErrorRaw, handleError, reset } = useApiErrors([
     'currentPassword',
     'newPassword',
     'newPasswordConfirmation',
@@ -103,8 +104,9 @@ async function onSubmit() {
                 />
             </UFormField>
 
+            <LoadErrorAlert v-if="generalErrorRaw" :title="generalError ?? t('unknownError')" :error="generalErrorRaw" />
             <UAlert
-                v-if="generalError"
+                v-else-if="generalError"
                 color="error"
                 :description="generalError"
                 icon="i-lucide-alert-circle"

--- a/src/components/settings/__tests__/ProfileSettings.spec.ts
+++ b/src/components/settings/__tests__/ProfileSettings.spec.ts
@@ -64,6 +64,11 @@ vi.mock('@/lang', () => ({
         { code: 'en', name: '🇺🇸 English', flag: '🇺🇸' },
         { code: 'uk', name: '🇺🇦 Українська', flag: '🇺🇦' },
     ],
+    default: {
+        global: {
+            t: (key: string) => key,
+        },
+    },
 }))
 
 const globalStubs = {
@@ -289,6 +294,21 @@ describe('ProfileSettings', () => {
 
         expect(mockSetProfile).toHaveBeenCalledWith(mockUser)
         expect(vm.successMessage).toBe('profileSettings.success')
+    })
+
+    it('shows LoadErrorAlert (no retry) and no plain UAlert for a non-422 updateProfile failure', async () => {
+        mockUpdateProfile.mockRejectedValue(new Error('network error'))
+
+        const wrapper = mount(ProfileSettings, globalStubs)
+        const vm = wrapper.vm as unknown as { onSubmit: () => Promise<void> }
+        await vm.onSubmit()
+        await nextTick()
+
+        const alert = wrapper.findComponent({ name: 'LoadErrorAlert' })
+        expect(alert.exists()).toBe(true)
+        expect(alert.props('retryable')).toBeFalsy()
+        // The stubbed plain UAlert only renders for the 422 branch (generalError without generalErrorRaw)
+        expect(wrapper.text()).not.toContain('validationError')
     })
 
     it('converts empty lastName to null on submit', async () => {

--- a/src/components/settings/__tests__/SecuritySettings.spec.ts
+++ b/src/components/settings/__tests__/SecuritySettings.spec.ts
@@ -131,6 +131,26 @@ describe('SecuritySettings', () => {
         expect(vm.form.newPasswordConfirmation).toBe('')
     })
 
+    it('shows LoadErrorAlert (no retry) and no plain UAlert for a non-422 updatePassword failure', async () => {
+        mockUpdatePassword.mockRejectedValue(new Error('network error'))
+
+        const wrapper = mount(SecuritySettings, globalStubs)
+        const vm = wrapper.vm as unknown as {
+            form: { currentPassword: string; newPassword: string; newPasswordConfirmation: string }
+            onSubmit: () => Promise<void>
+        }
+
+        vm.form.currentPassword = 'oldpass'
+        vm.form.newPassword = 'newpass123'
+        vm.form.newPasswordConfirmation = 'newpass123'
+        await vm.onSubmit()
+
+        const alert = wrapper.findComponent({ name: 'LoadErrorAlert' })
+        expect(alert.exists()).toBe(true)
+        expect(alert.props('retryable')).toBeFalsy()
+        expect(wrapper.text()).not.toContain('validationError')
+    })
+
     it('shows field error when API call fails', async () => {
         const axiosError = new AxiosError('Unauthorized')
         axiosError.response = {

--- a/src/components/settings/passkeys/PasskeysSettings.vue
+++ b/src/components/settings/passkeys/PasskeysSettings.vue
@@ -5,12 +5,15 @@ import { browserSupportsWebAuthn, startRegistration, WebAuthnError } from '@simp
 import type { Passkey } from '@/api/models/passkey'
 import { getPasskeys, initPasskey, storePasskey } from '@/api/profile/passkeys'
 import PasskeyItem from './PasskeyItem.vue'
+import LoadErrorAlert from '@/components/Shared/LoadErrorAlert.vue'
 
 const { t } = useI18n()
 
 const passkeys = shallowRef<Passkey[]>([])
 const passkeysSupported = shallowRef(false)
 const loading = shallowRef(false)
+const failed = shallowRef(false)
+const lastError = shallowRef<unknown>(null)
 const addLoading = shallowRef(false)
 const keyName = shallowRef('')
 const addError = shallowRef<string | null>(null)
@@ -23,10 +26,13 @@ onMounted(async () => {
 
 async function loadPasskeys() {
     loading.value = true
+    failed.value = false
+    lastError.value = null
     try {
         passkeys.value = await getPasskeys()
-    } catch {
-        // non-fatal
+    } catch (err) {
+        failed.value = true
+        lastError.value = err
     } finally {
         loading.value = false
     }
@@ -93,6 +99,14 @@ function onPasskeyDeleted(id: number) {
         <div v-if="loading" class="flex justify-center py-4">
             <UIcon name="i-lucide-loader-circle" class="size-5 animate-spin text-muted" />
         </div>
+
+        <LoadErrorAlert
+            v-else-if="failed"
+            :title="t('passkeySettings.loadingError')"
+            :error="lastError"
+            retryable
+            @retry="loadPasskeys()"
+        />
 
         <div v-else-if="passkeys.length === 0" class="text-sm text-muted py-2">
             {{ t('passkeySettings.yourPasskeys') }}: —

--- a/src/components/settings/passkeys/__tests__/PasskeysSettings.spec.ts
+++ b/src/components/settings/passkeys/__tests__/PasskeysSettings.spec.ts
@@ -104,6 +104,31 @@ describe('PasskeysSettings', () => {
         expect(vm.addError).not.toBe('Unexpected token in JSON')
     })
 
+    it('shows a retryable LoadErrorAlert when loading passkeys fails, and reloads on retry', async () => {
+        mockGetPasskeys.mockReset()
+        mockGetPasskeys.mockRejectedValueOnce(new Error('network error'))
+        mockGetPasskeys.mockResolvedValue([makePasskey()])
+
+        const wrapper = mount(PasskeysSettings, globalStubs)
+        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick()
+
+        const alert = wrapper.findComponent({ name: 'LoadErrorAlert' })
+        expect(alert.exists()).toBe(true)
+        expect(alert.props('retryable')).toBe(true)
+
+        const vm = wrapper.vm as unknown as { failed: boolean; passkeys: Passkey[] }
+        expect(vm.failed).toBe(true)
+
+        await alert.vm.$emit('retry')
+        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick()
+
+        expect(mockGetPasskeys).toHaveBeenCalledTimes(2)
+        expect(vm.failed).toBe(false)
+        expect(vm.passkeys).toHaveLength(1)
+    })
+
     it('appends stored passkey to list on success', async () => {
         const stored = makePasskey()
         mockInitPasskey.mockResolvedValue({ data: btoa(JSON.stringify({})), challenge: 'ch' })

--- a/src/components/tags/TagForm.vue
+++ b/src/components/tags/TagForm.vue
@@ -6,6 +6,7 @@ import type { Tag } from '@/api/models/tag'
 import { useApiErrors } from '@/composables/useApiErrors'
 import { parseTagInput } from '@/shared/strings'
 import TagChip from './Tag.vue'
+import LoadErrorAlert from '@/components/Shared/LoadErrorAlert.vue'
 
 const props = defineProps<{
     tag?: Tag | null
@@ -17,7 +18,7 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
-const { fieldErrors, generalError, reset: resetErrors, handleError } = useApiErrors([
+const { fieldErrors, generalError, generalErrorRaw, reset: resetErrors, handleError } = useApiErrors([
     'name',
     'icon',
 ])
@@ -168,8 +169,14 @@ defineExpose({ validationError })
             </p>
 
             <!-- General error -->
+            <LoadErrorAlert
+                v-if="generalErrorRaw"
+                :title="generalError ?? t('unknownError')"
+                :error="generalErrorRaw"
+                class="mt-3"
+            />
             <UAlert
-                v-if="generalError"
+                v-else-if="generalError"
                 color="error"
                 :description="generalError"
                 icon="i-lucide-alert-circle"

--- a/src/components/tags/__tests__/TagForm.spec.ts
+++ b/src/components/tags/__tests__/TagForm.spec.ts
@@ -235,6 +235,23 @@ describe('TagForm.vue', () => {
         })
     })
 
+    it('shows LoadErrorAlert (no retry) and no plain UAlert for a non-422 createTag failure', async () => {
+        mockCreateTag.mockRejectedValue(new Error('network error'))
+
+        const wrapper = mount(TagForm, makeGlobal())
+        await findNameInput(wrapper).setValue('Shopping')
+        await nextTick()
+
+        await wrapper.find('form').trigger('submit')
+
+        await vi.waitFor(() => {
+            expect(wrapper.findComponent({ name: 'LoadErrorAlert' }).exists()).toBe(true)
+        })
+
+        const alert = wrapper.findComponent({ name: 'LoadErrorAlert' })
+        expect(alert.props('retryable')).toBeFalsy()
+    })
+
     it('help text contains tags.nameRules', () => {
         const wrapper = mount(TagForm, makeGlobal())
         expect(wrapper.text()).toContain('tags.nameRules')

--- a/src/components/wallets/WalletCreate.vue
+++ b/src/components/wallets/WalletCreate.vue
@@ -8,12 +8,13 @@ import type { Currency } from '@/api/models/currency'
 import { useApiErrors } from '@/composables/useApiErrors'
 import { useProfileStore } from '@/stores/profile'
 import { useWalletsStore } from '@/stores/wallets'
+import LoadErrorAlert from '@/components/Shared/LoadErrorAlert.vue'
 
 const { t } = useI18n()
 const router = useRouter()
 const profileStore = useProfileStore()
 const walletsStore = useWalletsStore()
-const { fieldErrors, generalError, handleError, reset } = useApiErrors([
+const { fieldErrors, generalError, generalErrorRaw, handleError, reset } = useApiErrors([
     'name',
     'defaultCurrencyCode',
 ])
@@ -106,8 +107,9 @@ async function onSubmit() {
                 />
             </UFormField>
 
+            <LoadErrorAlert v-if="generalErrorRaw" :title="generalError ?? t('unknownError')" :error="generalErrorRaw" />
             <UAlert
-                v-if="generalError"
+                v-else-if="generalError"
                 color="error"
                 :description="generalError"
                 icon="i-lucide-alert-circle"

--- a/src/components/wallets/WalletEdit.vue
+++ b/src/components/wallets/WalletEdit.vue
@@ -9,13 +9,14 @@ import type { Wallet } from '@/api/models/wallet'
 import { useApiErrors } from '@/composables/useApiErrors'
 import { useWalletsStore } from '@/stores/wallets'
 import ConfirmModal from '@/components/Shared/ConfirmModal.vue'
+import LoadErrorAlert from '@/components/Shared/LoadErrorAlert.vue'
 
 const props = defineProps<{ wallet: Wallet }>()
 
 const { t } = useI18n()
 const router = useRouter()
 const walletsStore = useWalletsStore()
-const { fieldErrors, generalError, handleError, reset } = useApiErrors([
+const { fieldErrors, generalError, generalErrorRaw, handleError, reset } = useApiErrors([
     'name',
     'defaultCurrencyCode',
 ])
@@ -130,8 +131,9 @@ async function onDelete() {
                 />
             </UFormField>
 
+            <LoadErrorAlert v-if="generalErrorRaw" :title="generalError ?? t('unknownError')" :error="generalErrorRaw" />
             <UAlert
-                v-if="generalError"
+                v-else-if="generalError"
                 color="error"
                 :description="generalError"
                 icon="i-lucide-alert-circle"

--- a/src/components/wallets/WalletShare.vue
+++ b/src/components/wallets/WalletShare.vue
@@ -7,19 +7,19 @@ import { findUserByEmail, findUsersByCommonWallets } from '@/api/users'
 import type { Wallet } from '@/api/models/wallet'
 import type { User } from '@/api/models/user'
 import { useApiErrors } from '@/composables/useApiErrors'
-import { useNotifications } from '@/composables/useNotifications'
 import WalletSharedMember from './WalletSharedMember.vue'
+import LoadErrorAlert from '@/components/Shared/LoadErrorAlert.vue'
 
 const props = defineProps<{ wallet: Wallet }>()
 
 const { t } = useI18n()
 const router = useRouter()
-const { fieldErrors, handleError, reset } = useApiErrors(['email'])
-const { notifyError } = useNotifications()
+const { fieldErrors, generalError, generalErrorRaw, handleError, reset } = useApiErrors(['email'])
 
 const members = shallowRef<User[]>([])
 const commonUsers = shallowRef<User[]>([])
 const loadFailed = shallowRef(false)
+const loadLastError = shallowRef<unknown>(null)
 
 const searchEmail = shallowRef('')
 const foundUser = shallowRef<User | null>(null)
@@ -32,7 +32,9 @@ const filteredCommonUsers = computed(() =>
     commonUsers.value.filter(u => !memberIds.value.has(u.id) && u.id !== foundUser.value?.id),
 )
 
-onMounted(async () => {
+async function load() {
+    loadFailed.value = false
+    loadLastError.value = null
     try {
         const [walletUsers, common] = await Promise.all([
             getWalletUsers(props.wallet.id),
@@ -40,10 +42,13 @@ onMounted(async () => {
         ])
         members.value = walletUsers
         commonUsers.value = common
-    } catch {
+    } catch (error) {
         loadFailed.value = true
+        loadLastError.value = error
     }
-})
+}
+
+onMounted(load)
 
 async function onSearch() {
     reset()
@@ -59,6 +64,7 @@ async function onSearch() {
 }
 
 async function onInvite(user: User) {
+    reset()
     inviting.value = true
     try {
         await shareWallet(props.wallet.id, user.id)
@@ -67,7 +73,6 @@ async function onInvite(user: User) {
         searchEmail.value = ''
     } catch (error) {
         handleError(error)
-        notifyError(t('wallets.shareInviteError'))
     } finally {
         inviting.value = false
     }
@@ -106,10 +111,26 @@ function onClose() {
         </template>
 
         <div class="space-y-4">
-            <UAlert
+            <LoadErrorAlert
                 v-if="loadFailed"
+                :title="t('wallets.shareMembersLoadingError')"
+                :error="loadLastError"
+                retryable
+                @retry="load()"
+            />
+
+            <!-- generalErrorRaw is only ever set by onInvite's non-422 catch, so the specific
+                 shareInviteError message is always the right title here (never the generic
+                 unknownError fallback) -->
+            <LoadErrorAlert
+                v-if="generalErrorRaw"
+                :title="t('wallets.shareInviteError')"
+                :error="generalErrorRaw"
+            />
+            <UAlert
+                v-else-if="generalError"
                 color="error"
-                :description="t('wallets.shareMembersLoadingError')"
+                :description="generalError"
                 icon="i-lucide-alert-circle"
             />
 

--- a/src/components/wallets/WalletsActiveGridList.vue
+++ b/src/components/wallets/WalletsActiveGridList.vue
@@ -38,6 +38,7 @@ async function onDragEnd() {
             v-else-if="failed"
             :title="t('wallets.listLoadingError')"
             :error="lastError"
+            retryable
             @retry="walletsStore.loadActive()"
         />
 

--- a/src/components/wallets/WalletsGridList.vue
+++ b/src/components/wallets/WalletsGridList.vue
@@ -51,6 +51,7 @@ onMounted(reload)
             v-else-if="failed"
             :title="t('wallets.listLoadingError')"
             :error="lastError"
+            retryable
             @retry="reload()"
         />
 

--- a/src/components/wallets/__tests__/WalletCreate.spec.ts
+++ b/src/components/wallets/__tests__/WalletCreate.spec.ts
@@ -228,6 +228,26 @@ describe('WalletCreate', () => {
         expect(vm.generalError).toBe('Slug is already taken')
     })
 
+    it('shows LoadErrorAlert (no retry) and no plain UAlert for a non-422 createWallet failure', async () => {
+        mockCreateWallet.mockRejectedValue(new Error('network error'))
+
+        const wrapper = mount(WalletCreate, globalStubs)
+        const vm = wrapper.vm as unknown as {
+            form: { name: string; defaultCurrencyCode: string }
+            onSubmit: () => Promise<void>
+        }
+        vm.form.name = 'Test Wallet'
+        vm.form.defaultCurrencyCode = 'USD'
+        await wrapper.vm.$nextTick()
+
+        await vm.onSubmit()
+        await wrapper.vm.$nextTick()
+
+        const alert = wrapper.findComponent({ name: 'LoadErrorAlert' })
+        expect(alert.exists()).toBe(true)
+        expect(alert.props('retryable')).toBeFalsy()
+    })
+
     it('keeps a mixed known+unknown 422 split between fieldErrors and generalError', async () => {
         const axiosError = new AxiosError('Validation failed')
         axiosError.response = {

--- a/src/components/wallets/__tests__/WalletEdit.spec.ts
+++ b/src/components/wallets/__tests__/WalletEdit.spec.ts
@@ -206,6 +206,19 @@ describe('WalletEdit', () => {
         wrapper.unmount()
     })
 
+    it('shows LoadErrorAlert (no retry) and no plain UAlert for a non-422 updateWallet failure', async () => {
+        mockUpdateWallet.mockRejectedValue(new Error('network error'))
+
+        const wrapper = mount(WalletEdit, { props: { wallet: makeWallet() }, ...globalStubs })
+        const vm = wrapper.vm as unknown as { onSubmit: () => Promise<void> }
+        await vm.onSubmit()
+        await wrapper.vm.$nextTick()
+
+        const alert = wrapper.findComponent({ name: 'LoadErrorAlert' })
+        expect(alert.exists()).toBe(true)
+        expect(alert.props('retryable')).toBeFalsy()
+    })
+
     it('calls deleteWallet on confirmed delete', async () => {
         mockDeleteWallet.mockResolvedValue(undefined)
         mockLoadActive.mockResolvedValue(undefined)

--- a/src/components/wallets/__tests__/WalletShare.spec.ts
+++ b/src/components/wallets/__tests__/WalletShare.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ref } from 'vue'
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { Wallet } from '@/api/models/wallet'
 import { User } from '@/api/models/user'
@@ -11,13 +11,11 @@ const {
     mockGetWalletUsers,
     mockFindUsersByCommonWallets,
     mockShareWallet,
-    mockNotifyError,
     mockRouterPush,
 } = vi.hoisted(() => ({
     mockGetWalletUsers: vi.fn(),
     mockFindUsersByCommonWallets: vi.fn(),
     mockShareWallet: vi.fn(),
-    mockNotifyError: vi.fn(),
     mockRouterPush: vi.fn(),
 }))
 
@@ -44,16 +42,26 @@ vi.mock('@/api/users', () => ({
     findUsersByCommonWallets: mockFindUsersByCommonWallets,
 }))
 
-vi.mock('@/composables/useNotifications', () => ({
-    useNotifications: () => ({ notifyError: mockNotifyError }),
-}))
-
 vi.mock('@/composables/useApiErrors', () => ({
-    useApiErrors: () => ({
-        fieldErrors: ref({}),
-        handleError: vi.fn(),
-        reset: vi.fn(),
-    }),
+    useApiErrors: () => {
+        const fieldErrors = ref({})
+        const generalError = ref<string | null>(null)
+        const generalErrorRaw = ref<unknown>(null)
+        return {
+            fieldErrors,
+            generalError,
+            generalErrorRaw,
+            handleError: vi.fn((err: unknown) => {
+                generalError.value = 'unknownError'
+                generalErrorRaw.value = err
+            }),
+            reset: vi.fn(() => {
+                fieldErrors.value = {}
+                generalError.value = null
+                generalErrorRaw.value = null
+            }),
+        }
+    },
 }))
 
 const usd = new Currency({
@@ -116,7 +124,7 @@ describe('WalletShare', () => {
         mockFindUsersByCommonWallets.mockResolvedValue([])
     })
 
-    it('onInvite shows shareInviteError toast on failure', async () => {
+    it('onInvite failure shows a single, specific non-retryable LoadErrorAlert (no toast)', async () => {
         mockShareWallet.mockRejectedValue(new Error('fail'))
 
         const wrapper = mount(WalletShare, {
@@ -126,12 +134,16 @@ describe('WalletShare', () => {
 
         const vm = wrapper.vm as unknown as { onInvite: (user: User) => Promise<void> }
         await vm.onInvite(makeUser())
+        await wrapper.vm.$nextTick()
 
-        expect(mockNotifyError).toHaveBeenCalledWith('wallets.shareInviteError')
-        expect(mockNotifyError).not.toHaveBeenCalledWith('wallets.shareMembersLoadingError')
+        // Specific invite-error message, not the generic unknownError fallback
+        const alert = wrapper.findComponent({ name: 'LoadErrorAlert' })
+        expect(alert.exists()).toBe(true)
+        expect(alert.props('title')).toBe('wallets.shareInviteError')
+        expect(alert.props('retryable')).toBeFalsy()
     })
 
-    it('onInvite does not show error toast on success', async () => {
+    it('onInvite does not show any general-error alert on success', async () => {
         mockShareWallet.mockResolvedValue(undefined)
 
         const wrapper = mount(WalletShare, {
@@ -141,8 +153,55 @@ describe('WalletShare', () => {
 
         const vm = wrapper.vm as unknown as { onInvite: (user: User) => Promise<void> }
         await vm.onInvite(makeUser())
+        await wrapper.vm.$nextTick()
 
-        expect(mockNotifyError).not.toHaveBeenCalled()
+        expect(wrapper.findComponent({ name: 'LoadErrorAlert' }).exists()).toBe(false)
+    })
+
+    it('clears a stale invite-error alert once a later invite on the same instance succeeds', async () => {
+        mockShareWallet.mockRejectedValueOnce(new Error('fail'))
+
+        const wrapper = mount(WalletShare, {
+            props: { wallet: makeWallet() },
+            ...globalStubs,
+        })
+
+        const vm = wrapper.vm as unknown as { onInvite: (user: User) => Promise<void> }
+        await vm.onInvite(makeUser())
+        await wrapper.vm.$nextTick()
+
+        // Alert renders after the failure
+        expect(wrapper.findComponent({ name: 'LoadErrorAlert' }).exists()).toBe(true)
+
+        // Retry the invite — this time it succeeds
+        mockShareWallet.mockResolvedValueOnce(undefined)
+        await vm.onInvite(makeUser())
+        await wrapper.vm.$nextTick()
+
+        // Stale alert must not survive a subsequent successful invite
+        expect(wrapper.findComponent({ name: 'LoadErrorAlert' }).exists()).toBe(false)
+    })
+
+    it('shows a retryable LoadErrorAlert when loading members fails, and reloads on retry', async () => {
+        mockGetWalletUsers.mockReset()
+        mockGetWalletUsers.mockRejectedValueOnce(new Error('load fail'))
+        mockGetWalletUsers.mockResolvedValue([])
+
+        const wrapper = mount(WalletShare, {
+            props: { wallet: makeWallet() },
+            ...globalStubs,
+        })
+        await flushPromises()
+
+        const alerts = wrapper.findAllComponents({ name: 'LoadErrorAlert' })
+        const loadAlert = alerts.find(a => a.props('retryable'))
+        expect(loadAlert).toBeTruthy()
+
+        await loadAlert!.vm.$emit('retry')
+        await flushPromises()
+
+        expect(mockGetWalletUsers).toHaveBeenCalledTimes(2)
+        expect(wrapper.findAllComponents({ name: 'LoadErrorAlert' }).some(a => a.props('retryable'))).toBe(false)
     })
 
     it('close button navigates back to wallets.show', async () => {

--- a/src/components/wallets/charges/ChargeCreate.vue
+++ b/src/components/wallets/charges/ChargeCreate.vue
@@ -11,6 +11,7 @@ import { useAuthStore } from '@/stores/auth'
 import ChargeTitleFormInput from './ChargeTitleFormInput.vue'
 import TagFormInput from '@/components/tags/TagFormInput.vue'
 import TagChip from '@/components/tags/Tag.vue'
+import LoadErrorAlert from '@/components/Shared/LoadErrorAlert.vue'
 
 const props = defineProps<{
     wallet: Wallet
@@ -24,7 +25,7 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
-const { fieldErrors, generalError, reset: resetErrors, handleError } = useApiErrors([
+const { fieldErrors, generalError, generalErrorRaw, reset: resetErrors, handleError } = useApiErrors([
     'amount',
     'type',
     'title',
@@ -279,8 +280,9 @@ const formDate = computed<CalendarDate | null>({
         </div>
 
         <!-- Error message -->
+        <LoadErrorAlert v-if="generalErrorRaw" :title="generalError ?? t('unknownError')" :error="generalErrorRaw" />
         <UAlert
-            v-if="generalError"
+            v-else-if="generalError"
             color="error"
             :description="generalError"
             icon="i-lucide-alert-circle"

--- a/src/components/wallets/charges/ChargeEdit.vue
+++ b/src/components/wallets/charges/ChargeEdit.vue
@@ -11,6 +11,7 @@ import { useAuthStore } from '@/stores/auth'
 import ChargeTitleFormInput from './ChargeTitleFormInput.vue'
 import TagFormInput from '@/components/tags/TagFormInput.vue'
 import TagChip from '@/components/tags/Tag.vue'
+import LoadErrorAlert from '@/components/Shared/LoadErrorAlert.vue'
 
 const props = defineProps<{
     wallet: Wallet | WalletShort
@@ -24,7 +25,7 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
-const { fieldErrors, generalError, reset: resetErrors, handleError } = useApiErrors([
+const { fieldErrors, generalError, generalErrorRaw, reset: resetErrors, handleError } = useApiErrors([
     'amount',
     'type',
     'title',
@@ -249,8 +250,9 @@ const formDate = computed<CalendarDate | null>({
         </div>
 
         <!-- Error -->
+        <LoadErrorAlert v-if="generalErrorRaw" :title="generalError ?? t('unknownError')" :error="generalErrorRaw" />
         <UAlert
-            v-if="generalError"
+            v-else-if="generalError"
             color="error"
             :description="generalError"
             icon="i-lucide-alert-circle"

--- a/src/components/wallets/charges/ChargesFlowChart.vue
+++ b/src/components/wallets/charges/ChargesFlowChart.vue
@@ -18,6 +18,7 @@ import { getChargesFlowByDate, type ChargesFlowDataPoint, type GetChargesFlowPar
 import type { Currency } from '@/api/models/currency'
 import type { Tag } from '@/api/models/tag'
 import { useMoneyFormatter } from '@/composables/useMoneyFormatter'
+import LoadErrorAlert from '@/components/Shared/LoadErrorAlert.vue'
 
 ChartJS.register(Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale)
 
@@ -37,6 +38,7 @@ type GroupBy = 'day' | 'month' | 'year'
 const groupBy = ref<GroupBy>('day')
 const loading = ref(false)
 const error = ref<string | null>(null)
+const lastError = ref<unknown>(null)
 const dataPoints = ref<ChargesFlowDataPoint[]>([])
 const hasLoaded = ref(false)
 
@@ -143,6 +145,7 @@ const chartOptions = computed<ChartOptions<'bar'>>(() => ({
 async function loadData() {
     loading.value = true
     error.value = null
+    lastError.value = null
     try {
         const params: GetChargesFlowParams = { 'group-by': groupBy.value }
         if (props.tags?.length) {
@@ -152,8 +155,9 @@ async function loadData() {
         if (props.dateTo) params['date-to'] = props.dateTo
         dataPoints.value = await getChargesFlowByDate(props.walletId, params)
         hasLoaded.value = true
-    } catch {
+    } catch (err) {
         error.value = t('wallets.chartLoadingError')
+        lastError.value = err
     } finally {
         loading.value = false
     }
@@ -181,11 +185,12 @@ defineExpose({ reload: loadData, chartOptions })
             />
         </div>
 
-        <UAlert
+        <LoadErrorAlert
             v-if="error && !hasLoaded"
-            color="error"
-            :description="error"
-            icon="i-lucide-alert-circle"
+            :title="error"
+            :error="lastError"
+            retryable
+            @retry="loadData()"
         />
 
         <div v-else class="relative h-[300px]">

--- a/src/components/wallets/charges/ChargesList.vue
+++ b/src/components/wallets/charges/ChargesList.vue
@@ -11,6 +11,7 @@ import ChargeItem from './ChargeItem.vue'
 import { useWalletsStore } from '@/stores/wallets'
 import { useMoneyFormatter } from '@/composables/useMoneyFormatter'
 import { useChargesGrouping } from '@/composables/useChargesGrouping'
+import LoadErrorAlert from '@/components/Shared/LoadErrorAlert.vue'
 
 const props = defineProps<{
     wallet: Wallet
@@ -37,6 +38,7 @@ const pagination = ref<Pagination | null>(null)
 const loading = ref(false)
 const loadingMore = ref(false)
 const error = ref<string | null>(null)
+const lastError = ref<unknown>(null)
 const currentPage = ref(1)
 const sentinelRef = ref<HTMLElement | null>(null)
 let observer: IntersectionObserver | null = null
@@ -117,6 +119,7 @@ async function loadCharges(page = 1, append = false) {
         loading.value = true
     }
     error.value = null
+    lastError.value = null
 
     const params: GetChargesParams = { page }
     if (props.filter?.dateFrom) params['date-from'] = props.filter.dateFrom
@@ -133,9 +136,10 @@ async function loadCharges(page = 1, append = false) {
         }
         pagination.value = result.pagination
         currentPage.value = page
-    } catch {
+    } catch (err) {
         if (token !== loadToken) return
         error.value = append ? t('charges.loadingMoreError') : t('charges.loadingError')
+        lastError.value = err
         if (!append) charges.value = []
     } finally {
         if (token === loadToken) {
@@ -230,23 +234,14 @@ defineExpose({ onChargeCreated })
         </div>
 
         <!-- Error -->
-        <UAlert
+        <LoadErrorAlert
             v-if="error && !loading"
-            color="error"
-            :description="error"
-            icon="i-lucide-alert-circle"
+            :title="error"
+            :error="lastError"
+            retryable
             class="my-3"
+            @retry="loadCharges(1)"
         />
-        <div v-if="error && !loading" class="flex justify-center mb-3">
-            <UButton
-                variant="outline"
-                color="neutral"
-                size="md"
-                @click="loadCharges(1)"
-            >
-                {{ t('retry') }}
-            </UButton>
-        </div>
 
         <!-- Charges list -->
         <div v-if="!error">

--- a/src/components/wallets/charges/ChargesTotalChart.vue
+++ b/src/components/wallets/charges/ChargesTotalChart.vue
@@ -16,6 +16,7 @@ import { getWalletTags } from '@/api/tags'
 import type { Currency } from '@/api/models/currency'
 import type { Tag } from '@/api/models/tag'
 import { useMoneyFormatter } from '@/composables/useMoneyFormatter'
+import LoadErrorAlert from '@/components/Shared/LoadErrorAlert.vue'
 
 ChartJS.register(Title, Tooltip, Legend, ArcElement)
 
@@ -33,6 +34,7 @@ const { format } = useMoneyFormatter()
 
 const loading = ref(false)
 const error = ref<string | null>(null)
+const lastError = ref<unknown>(null)
 const expenseData = ref<ChargesTotalDataPoint[]>([])
 const incomeData = ref<ChargesTotalDataPoint[]>([])
 const allWalletTags = ref<Tag[]>([])
@@ -162,6 +164,7 @@ const chartOptions = computed(() => buildChartOptions())
 async function loadData() {
     loading.value = true
     error.value = null
+    lastError.value = null
     try {
         const dateParams = {
             ...(props.dateFrom ? { 'date-from': props.dateFrom } : {}),
@@ -177,8 +180,9 @@ async function loadData() {
         incomeData.value = incomeResult
         allWalletTags.value = resolvedTags
         hasLoaded.value = true
-    } catch {
+    } catch (err) {
         error.value = t('wallets.chartLoadingError')
+        lastError.value = err
     } finally {
         loading.value = false
     }
@@ -197,11 +201,12 @@ defineExpose({ reload: loadData, sliceColor, expenseChartData, incomeChartData }
 
 <template>
     <div>
-        <UAlert
+        <LoadErrorAlert
             v-if="error && !hasLoaded"
-            color="error"
-            :description="error"
-            icon="i-lucide-alert-circle"
+            :title="error"
+            :error="lastError"
+            retryable
+            @retry="loadData()"
         />
 
         <div v-else class="relative">

--- a/src/components/wallets/charges/TagChargesFlowChart.vue
+++ b/src/components/wallets/charges/TagChargesFlowChart.vue
@@ -17,6 +17,7 @@ import { getTagChargesFlow, type ChargesFlowDataPoint, type GetChargesFlowParams
 import type { Currency } from '@/api/models/currency'
 import type { FilterState } from '@/components/wallets/charges/ChargesFilter.vue'
 import { useMoneyFormatter } from '@/composables/useMoneyFormatter'
+import LoadErrorAlert from '@/components/Shared/LoadErrorAlert.vue'
 
 ChartJS.register(Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale)
 
@@ -34,6 +35,7 @@ type GroupBy = 'day' | 'month' | 'year'
 const groupBy = shallowRef<GroupBy>('day')
 const loading = shallowRef(false)
 const error = shallowRef<string | null>(null)
+const lastError = shallowRef<unknown>(null)
 const dataPoints = shallowRef<ChargesFlowDataPoint[]>([])
 const hasLoaded = shallowRef(false)
 
@@ -99,14 +101,16 @@ const chartOptions = computed<ChartOptions<'bar'>>(() => ({
 async function loadData() {
     loading.value = true
     error.value = null
+    lastError.value = null
     try {
         const params: GetChargesFlowParams = { 'group-by': groupBy.value }
         if (props.filter?.dateFrom) params['date-from'] = props.filter.dateFrom
         if (props.filter?.dateTo) params['date-to'] = props.filter.dateTo
         dataPoints.value = await getTagChargesFlow(props.tagId, params)
         hasLoaded.value = true
-    } catch {
+    } catch (err) {
         error.value = t('wallets.chartLoadingError')
+        lastError.value = err
     } finally {
         loading.value = false
     }
@@ -134,11 +138,12 @@ defineExpose({ reload: loadData, chartOptions })
             />
         </div>
 
-        <UAlert
+        <LoadErrorAlert
             v-if="error && !hasLoaded"
-            color="error"
-            :description="error"
-            icon="i-lucide-alert-circle"
+            :title="error"
+            :error="lastError"
+            retryable
+            @retry="loadData()"
         />
 
         <div v-else class="relative h-[300px]">

--- a/src/components/wallets/charges/__tests__/ChargeCreate.spec.ts
+++ b/src/components/wallets/charges/__tests__/ChargeCreate.spec.ts
@@ -116,6 +116,29 @@ describe('ChargeCreate', () => {
         expect(callArgs[1].type).toBe('-') // default is expense
     })
 
+    it('shows LoadErrorAlert (no retry) and no plain UAlert for a non-422 createCharge failure', async () => {
+        mockCreateCharge.mockRejectedValue(new Error('network error'))
+
+        const wrapper = shallowMount(ChargeCreate, {
+            props: { wallet: makeWallet() },
+        })
+
+        const vm = wrapper.vm as unknown as { amount: number | null; title: string }
+        vm.amount = 50
+        vm.title = 'Test charge'
+
+        await wrapper.find('form').trigger('submit')
+
+        await vi.waitFor(() => {
+            const alert = wrapper.findComponent({ name: 'LoadErrorAlert' })
+            expect(alert.exists()).toBe(true)
+        })
+
+        const alert = wrapper.findComponent({ name: 'LoadErrorAlert' })
+        expect(alert.props('retryable')).toBeFalsy()
+        expect(wrapper.findComponent({ name: 'UAlert' }).exists()).toBe(false)
+    })
+
     it('emits charge-created after successful submission', async () => {
         const charge = makeCharge(50)
         mockCreateCharge.mockResolvedValue(charge)

--- a/src/components/wallets/charges/__tests__/ChargeEdit.spec.ts
+++ b/src/components/wallets/charges/__tests__/ChargeEdit.spec.ts
@@ -23,8 +23,9 @@ vi.mock('vue-router', () => ({
     useRoute: () => ({ params: {} }),
 }))
 
+const mockUpdateCharge = vi.fn()
 vi.mock('@/api/charges', () => ({
-    updateCharge: vi.fn(),
+    updateCharge: (...args: unknown[]) => mockUpdateCharge(...args),
     getChargeTitles: vi.fn().mockResolvedValue([]),
 }))
 
@@ -87,6 +88,25 @@ const tooltipStub = {
 describe('ChargeEdit', () => {
     beforeEach(() => {
         setActivePinia(createPinia())
+        mockUpdateCharge.mockReset()
+    })
+
+    it('shows LoadErrorAlert (no retry) and no plain UAlert for a non-422 updateCharge failure', async () => {
+        mockUpdateCharge.mockRejectedValue(new Error('network error'))
+
+        const wrapper = shallowMount(ChargeEdit, {
+            props: { wallet: makeWallet(), charge: makeCharge() },
+        })
+
+        await wrapper.find('form').trigger('submit')
+
+        await vi.waitFor(() => {
+            expect(wrapper.findComponent({ name: 'LoadErrorAlert' }).exists()).toBe(true)
+        })
+
+        const alert = wrapper.findComponent({ name: 'LoadErrorAlert' })
+        expect(alert.props('retryable')).toBeFalsy()
+        expect(wrapper.findComponent({ name: 'UAlert' }).exists()).toBe(false)
     })
 
     it('submit button tooltip is active (data-tip-disabled=false) when email is not confirmed', () => {

--- a/src/components/wallets/charges/__tests__/ChargesFlowChart.spec.ts
+++ b/src/components/wallets/charges/__tests__/ChargesFlowChart.spec.ts
@@ -161,4 +161,27 @@ describe('ChargesFlowChart', () => {
         expect(result).toBe('1235')
         expect(String(result)).not.toMatch(/[.,]\d{2}$/)
     })
+
+    it('shows a retryable LoadErrorAlert on load failure, and reloads on retry', async () => {
+        mockGetChargesFlowByDate.mockRejectedValue(new Error('network error'))
+
+        const wrapper = shallowMount(ChargesFlowChart, {
+            props: { walletId: 1, currency: usd },
+        })
+        await new Promise(r => setTimeout(r, 0))
+        await nextTick()
+
+        const alert = wrapper.findComponent({ name: 'LoadErrorAlert' })
+        expect(alert.exists()).toBe(true)
+        expect(alert.props('retryable')).toBe(true)
+
+        mockGetChargesFlowByDate.mockResolvedValue(nonZeroData)
+
+        await alert.vm.$emit('retry')
+        await new Promise(r => setTimeout(r, 0))
+        await nextTick()
+
+        expect(wrapper.findComponent({ name: 'LoadErrorAlert' }).exists()).toBe(false)
+        expect(wrapper.findComponent({ name: 'Bar' }).exists()).toBe(true)
+    })
 })

--- a/src/components/wallets/charges/__tests__/ChargesList.spec.ts
+++ b/src/components/wallets/charges/__tests__/ChargesList.spec.ts
@@ -398,7 +398,7 @@ describe('ChargesList', () => {
         expect(vm.charges.length).toBe(0)
     })
 
-    it('shows retry button on load error and reloads charges on click', async () => {
+    it('shows LoadErrorAlert with retryable on load error and reloads charges when retry is emitted', async () => {
         mockGetCharges.mockRejectedValue(new Error('network error'))
 
         const wrapper = shallowMount(ChargesList, {
@@ -415,16 +415,16 @@ describe('ChargesList', () => {
         const vm = wrapper.vm as unknown as { error: string | null; loadCharges: (page: number) => Promise<void> }
         expect(vm.error).toBeTruthy()
 
-        // In shallowMount, UButton renders as <u-button-stub> — the wrapper div with
-        // v-if="error && !loading" must be in the DOM
-        const retryWrapper = wrapper.find('.flex.justify-center.mb-3')
-        expect(retryWrapper.exists()).toBe(true)
+        // In shallowMount, LoadErrorAlert renders as a stub — v-if="error && !loading" must be in the DOM
+        const alert = wrapper.findComponent({ name: 'LoadErrorAlert' })
+        expect(alert.exists()).toBe(true)
+        expect(alert.props('retryable')).toBe(true)
 
         // Set up a successful response for the retry
         mockGetCharges.mockResolvedValue({ data: [makeCharge()], pagination: makePagination() })
 
-        // Call loadCharges directly (equivalent to clicking the retry button)
-        await vm.loadCharges(1)
+        // Emit retry (equivalent to clicking the LoadErrorAlert's retry action)
+        await alert.vm.$emit('retry')
         await nextTick()
 
         // getCharges must have been called a second time

--- a/src/components/wallets/charges/__tests__/ChargesTotalChart.spec.ts
+++ b/src/components/wallets/charges/__tests__/ChargesTotalChart.spec.ts
@@ -100,6 +100,35 @@ describe('ChargesTotalChart', () => {
         expect(normalColor).not.toBe('#4b5563')
     })
 
+    it('shows a retryable LoadErrorAlert on load failure, and reloads on retry', async () => {
+        const { getChargesTotalByType } = await import('@/api/graph')
+        const mockFn = getChargesTotalByType as ReturnType<typeof vi.fn>
+        mockFn.mockRejectedValue(new Error('network error'))
+
+        const wrapper = shallowMount(ChargesTotalChart, {
+            props: { walletId: 1, currency: usd },
+        })
+        await new Promise(r => setTimeout(r, 0))
+        await nextTick()
+
+        const alert = wrapper.findComponent({ name: 'LoadErrorAlert' })
+        expect(alert.exists()).toBe(true)
+        expect(alert.props('retryable')).toBe(true)
+
+        mockFn.mockImplementation((_walletId: number, params?: Record<string, string>) => {
+            if (params?.['charge-type'] === 'expense') return Promise.resolve([{ amount: 500, tags: [1] }])
+            if (params?.['charge-type'] === 'income') return Promise.resolve([{ amount: 3000, tags: [2] }])
+            return Promise.resolve([])
+        })
+
+        await alert.vm.$emit('retry')
+        await new Promise(r => setTimeout(r, 0))
+        await nextTick()
+
+        expect(wrapper.findComponent({ name: 'LoadErrorAlert' }).exists()).toBe(false)
+        expect(wrapper.findAllComponents({ name: 'Doughnut' })).toHaveLength(2)
+    })
+
     it('backgroundColor array in buildChartData uses distinct colors for tags:[] and tags:[-1]', async () => {
         const { getChargesTotalByType } = await import('@/api/graph')
         const mockFn = getChargesTotalByType as ReturnType<typeof vi.fn>

--- a/src/components/wallets/charges/__tests__/TagChargesFlowChart.spec.ts
+++ b/src/components/wallets/charges/__tests__/TagChargesFlowChart.spec.ts
@@ -161,4 +161,27 @@ describe('TagChargesFlowChart', () => {
         expect(result).toBe('1235')
         expect(String(result)).not.toMatch(/[.,]\d{2}$/)
     })
+
+    it('shows a retryable LoadErrorAlert on load failure, and reloads on retry', async () => {
+        mockGetTagChargesFlow.mockRejectedValue(new Error('network error'))
+
+        const wrapper = shallowMount(TagChargesFlowChart, {
+            props: { tagId: 1, currency: usd },
+        })
+        await new Promise(r => setTimeout(r, 0))
+        await nextTick()
+
+        const alert = wrapper.findComponent({ name: 'LoadErrorAlert' })
+        expect(alert.exists()).toBe(true)
+        expect(alert.props('retryable')).toBe(true)
+
+        mockGetTagChargesFlow.mockResolvedValue(nonZeroData)
+
+        await alert.vm.$emit('retry')
+        await new Promise(r => setTimeout(r, 0))
+        await nextTick()
+
+        expect(wrapper.findComponent({ name: 'LoadErrorAlert' }).exists()).toBe(false)
+        expect(wrapper.findComponent({ name: 'Bar' }).exists()).toBe(true)
+    })
 })

--- a/src/components/wallets/limits/LimitForm.vue
+++ b/src/components/wallets/limits/LimitForm.vue
@@ -8,6 +8,7 @@ import type { Tag } from '@/api/models/tag'
 import { useApiErrors } from '@/composables/useApiErrors'
 import TagFormInput from '@/components/tags/TagFormInput.vue'
 import TagChip from '@/components/tags/Tag.vue'
+import LoadErrorAlert from '@/components/Shared/LoadErrorAlert.vue'
 
 const props = defineProps<{
     wallet: Wallet
@@ -21,7 +22,7 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
-const { fieldErrors, generalError, reset: resetErrors, handleError } = useApiErrors([
+const { fieldErrors, generalError, generalErrorRaw, reset: resetErrors, handleError } = useApiErrors([
     'tags',
     'amount',
     'type',
@@ -154,8 +155,9 @@ function onCancel() {
         </div>
 
         <!-- Error message -->
+        <LoadErrorAlert v-if="generalErrorRaw" :title="generalError ?? t('unknownError')" :error="generalErrorRaw" />
         <UAlert
-            v-if="generalError"
+            v-else-if="generalError"
             color="error"
             :description="generalError"
             icon="i-lucide-alert-circle"

--- a/src/components/wallets/limits/WalletLimitsTotal.vue
+++ b/src/components/wallets/limits/WalletLimitsTotal.vue
@@ -9,6 +9,7 @@ import { getWalletsWithLimits } from '@/api/wallets'
 import WalletLimitItem from './WalletLimitItem.vue'
 import LimitForm from './LimitForm.vue'
 import MoneyAmount from '@/components/Shared/MoneyAmount.vue'
+import LoadErrorAlert from '@/components/Shared/LoadErrorAlert.vue'
 
 const props = defineProps<{
     wallet: Wallet
@@ -18,6 +19,8 @@ const { t } = useI18n()
 
 const limits = ref<WalletLimit[]>([])
 const loading = ref(false)
+const failed = ref(false)
+const lastError = ref<unknown>(null)
 const showCreateForm = ref(false)
 const walletsWithLimits = ref<Wallet[]>([])
 const copyLoading = ref(false)
@@ -62,6 +65,8 @@ async function loadWalletsWithLimits() {
 
 async function loadLimits() {
     loading.value = true
+    failed.value = false
+    lastError.value = null
     try {
         limits.value = await getLimits(props.wallet.id)
         if (limits.value.length === 0) {
@@ -69,8 +74,9 @@ async function loadLimits() {
         } else {
             walletsWithLimits.value = []
         }
-    } catch {
-        // Silently fail
+    } catch (err) {
+        failed.value = true
+        lastError.value = err
     } finally {
         loading.value = false
     }
@@ -128,6 +134,15 @@ defineExpose({ reload: loadLimits, copyDropdownItems })
         <div v-if="loading" class="flex justify-center py-4">
             <UIcon name="i-lucide-loader-circle" class="size-5 animate-spin text-muted" />
         </div>
+
+        <!-- Error -->
+        <LoadErrorAlert
+            v-else-if="failed"
+            :title="t('limits.loadingError')"
+            :error="lastError"
+            retryable
+            @retry="loadLimits()"
+        />
 
         <!-- Limits list -->
         <template v-else>

--- a/src/components/wallets/limits/__tests__/LimitForm.spec.ts
+++ b/src/components/wallets/limits/__tests__/LimitForm.spec.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+import { shallowMount } from '@vue/test-utils'
+import { AxiosError } from 'axios'
+import { Wallet } from '@/api/models/wallet'
+import { Currency } from '@/api/models/currency'
+import { Limit } from '@/api/models/limit'
+import { Tag } from '@/api/models/tag'
+import LimitForm from '../LimitForm.vue'
+
+vi.mock('vue-i18n', () => ({
+    useI18n: () => ({
+        t: (key: string) => key,
+        locale: ref('en'),
+    }),
+    createI18n: () => ({
+        global: { t: (key: string) => key, locale: { value: 'en' }, setLocaleMessage: vi.fn() },
+    }),
+}))
+
+const mockCreateLimit = vi.fn()
+const mockUpdateLimit = vi.fn()
+vi.mock('@/api/limits', () => ({
+    createLimit: (...args: unknown[]) => mockCreateLimit(...args),
+    updateLimit: (...args: unknown[]) => mockUpdateLimit(...args),
+}))
+
+const usd = new Currency({
+    id: 'USD',
+    code: 'USD',
+    name: 'US Dollar',
+    char: '$',
+    rate: 1.0,
+    updatedAt: new Date(),
+})
+
+function makeWallet(): Wallet {
+    return new Wallet({
+        id: 1,
+        name: 'Test Wallet',
+        slug: 'test-wallet',
+        totalAmount: 1000,
+        isActive: true,
+        isPublic: false,
+        isArchived: false,
+        defaultCurrencyCode: 'USD',
+        defaultCurrency: usd,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        users: [],
+        latestCharges: [],
+    })
+}
+
+function makeTag(id = 1, name = 'Food'): Tag {
+    return new Tag({
+        id, name, icon: null, color: null, userId: 1,
+        createdAt: new Date(), updatedAt: new Date(),
+    })
+}
+
+function makeLimit(overrides: Partial<{ id: number; operation: '+' | '-'; amount: number; tags: Tag[] }> = {}): Limit {
+    return new Limit({
+        id: overrides.id ?? 1,
+        operation: overrides.operation ?? '-',
+        amount: overrides.amount ?? 500,
+        walletId: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        tags: overrides.tags ?? [makeTag()],
+        wallet: null,
+    })
+}
+
+describe('LimitForm', () => {
+    beforeEach(() => {
+        mockCreateLimit.mockReset()
+        mockUpdateLimit.mockReset()
+    })
+
+    it('defaults to a blank expense form when no edit prop is provided', () => {
+        const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet() } })
+        const vm = wrapper.vm as unknown as { operation: '+' | '-'; amount: number | null; selectedTags: Tag[] }
+        expect(vm.operation).toBe('-')
+        expect(vm.amount).toBeNull()
+        expect(vm.selectedTags).toHaveLength(0)
+        expect(wrapper.find('form').exists()).toBe(true)
+    })
+
+    it('pre-fills operation, amount and tags from the edit prop', () => {
+        const limit = makeLimit({ operation: '+', amount: 250 })
+        const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet(), edit: limit } })
+
+        const vm = wrapper.vm as unknown as { operation: '+' | '-'; amount: number | null; selectedTags: Tag[] }
+        expect(vm.operation).toBe('+')
+        expect(vm.amount).toBe(250)
+        expect(vm.selectedTags).toHaveLength(1)
+    })
+
+    it('calls createLimit with the entered amount, operation and tags on submit', async () => {
+        const tag = makeTag()
+        mockCreateLimit.mockResolvedValue(makeLimit({ tags: [tag] }))
+
+        const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet() } })
+        const vm = wrapper.vm as unknown as {
+            amount: number | null
+            operation: '+' | '-'
+            selectedTags: Tag[]
+        }
+        vm.amount = 100
+        vm.operation = '-'
+        vm.selectedTags = [tag]
+
+        await wrapper.find('form').trigger('submit')
+
+        await vi.waitFor(() => {
+            expect(mockCreateLimit).toHaveBeenCalledTimes(1)
+        })
+
+        const [walletId, request] = mockCreateLimit.mock.calls[0]
+        expect(walletId).toBe(1)
+        expect(request).toEqual({ type: '-', amount: 100, tags: [tag.id] })
+    })
+
+    it('emits created and resets the form after a successful create', async () => {
+        const limit = makeLimit()
+        mockCreateLimit.mockResolvedValue(limit)
+
+        const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet() } })
+        const vm = wrapper.vm as unknown as { amount: number | null }
+        vm.amount = 100
+
+        await wrapper.find('form').trigger('submit')
+
+        await vi.waitFor(() => {
+            expect(wrapper.emitted('created')).toBeTruthy()
+        })
+        expect(wrapper.emitted('created')![0]).toEqual([limit])
+        expect(vm.amount).toBeNull()
+    })
+
+    it('calls updateLimit and emits updated in edit mode (form is not reset)', async () => {
+        const limit = makeLimit({ id: 7 })
+        const updated = makeLimit({ id: 7, amount: 999 })
+        mockUpdateLimit.mockResolvedValue(updated)
+
+        const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet(), edit: limit } })
+        await wrapper.find('form').trigger('submit')
+
+        await vi.waitFor(() => {
+            expect(mockUpdateLimit).toHaveBeenCalledWith(1, 7, expect.objectContaining({ amount: 500 }))
+        })
+        expect(wrapper.emitted('updated')![0]).toEqual([updated])
+    })
+
+    it('shows LoadErrorAlert (no retry) and no plain UAlert for a non-422 createLimit failure', async () => {
+        mockCreateLimit.mockRejectedValue(new Error('network error'))
+
+        const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet() } })
+        const vm = wrapper.vm as unknown as { amount: number | null }
+        vm.amount = 100
+
+        await wrapper.find('form').trigger('submit')
+
+        await vi.waitFor(() => {
+            expect(wrapper.findComponent({ name: 'LoadErrorAlert' }).exists()).toBe(true)
+        })
+
+        const alert = wrapper.findComponent({ name: 'LoadErrorAlert' })
+        expect(alert.props('retryable')).toBeFalsy()
+        expect(wrapper.findComponent({ name: 'UAlert' }).exists()).toBe(false)
+    })
+
+    it('routes a 422 error for a field the form does not render into generalError, not LoadErrorAlert', async () => {
+        const axiosError = new AxiosError('Validation failed')
+        axiosError.response = {
+            status: 422,
+            data: { errors: { walletId: ['Wallet is archived'] } },
+            headers: {},
+            config: {} as never,
+            statusText: 'Unprocessable Entity',
+        }
+        mockCreateLimit.mockRejectedValue(axiosError)
+
+        const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet() } })
+        const vm = wrapper.vm as unknown as {
+            amount: number | null
+            fieldErrors: Record<string, string[]>
+            generalError: string | null
+        }
+        vm.amount = 100
+
+        await wrapper.find('form').trigger('submit')
+
+        await vi.waitFor(() => {
+            expect(vm.generalError).toBe('Wallet is archived')
+        })
+        expect(vm.fieldErrors.walletId).toBeUndefined()
+        expect(wrapper.findComponent({ name: 'LoadErrorAlert' }).exists()).toBe(false)
+    })
+
+    it('cancel resets the form and emits cancelled', async () => {
+        const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet() } })
+        const vm = wrapper.vm as unknown as {
+            amount: number | null
+            onCancel: () => void
+        }
+        vm.amount = 42
+        vm.onCancel()
+
+        expect(vm.amount).toBeNull()
+        expect(wrapper.emitted('cancelled')).toBeTruthy()
+    })
+})

--- a/src/components/wallets/limits/__tests__/WalletLimitsTotal.spec.ts
+++ b/src/components/wallets/limits/__tests__/WalletLimitsTotal.spec.ts
@@ -186,4 +186,22 @@ describe('WalletLimitsTotal', () => {
             'Wallet 11', 'Wallet 10', 'Wallet 9', 'Wallet 8', 'Wallet 7',
         ])
     })
+
+    it('shows a retryable LoadErrorAlert when loading limits fails, and reloads on retry', async () => {
+        vi.mocked(getLimits).mockRejectedValueOnce(new Error('network error'))
+        vi.mocked(getLimits).mockResolvedValue([makeWalletLimit()])
+
+        const wrapper = mountComponent()
+        await flushPromises()
+
+        const alert = wrapper.findComponent({ name: 'LoadErrorAlert' })
+        expect(alert.exists()).toBe(true)
+        expect(alert.props('retryable')).toBe(true)
+
+        await alert.vm.$emit('retry')
+        await flushPromises()
+
+        expect(getLimits).toHaveBeenCalledTimes(2)
+        expect(wrapper.findComponent({ name: 'LoadErrorAlert' }).exists()).toBe(false)
+    })
 })

--- a/src/composables/__tests__/useApiErrors.spec.ts
+++ b/src/composables/__tests__/useApiErrors.spec.ts
@@ -28,9 +28,10 @@ describe('useApiErrors', () => {
     })
 
     it('initial state: no errors', () => {
-        const { fieldErrors, generalError } = useApiErrors()
+        const { fieldErrors, generalError, generalErrorRaw } = useApiErrors()
         expect(fieldErrors.value).toEqual({})
         expect(generalError.value).toBeNull()
+        expect(generalErrorRaw.value).toBeNull()
     })
 
     it('extracts errors.name[0] from a mock 422 response', () => {
@@ -170,6 +171,86 @@ describe('useApiErrors', () => {
         expect(fieldErrors.value).toEqual({})
         expect(generalError.value).toBe('unknownError')
         expect(consoleSpy).toHaveBeenCalled()
+    })
+
+    describe('generalErrorRaw exposure', () => {
+        it('is set to the raw error for a non-HTTP error', () => {
+            vi.spyOn(console, 'error').mockImplementation(() => {})
+            const { generalErrorRaw, handleError } = useApiErrors()
+
+            const originalError = new Error('Network failure')
+            handleError(originalError)
+
+            expect(generalErrorRaw.value).toBe(originalError)
+        })
+
+        it('is set to the raw AxiosError for a non-422 HTTP failure', () => {
+            vi.spyOn(console, 'error').mockImplementation(() => {})
+            const { generalErrorRaw, handleError } = useApiErrors()
+
+            const err = makeAxiosError(400, { message: 'Bad request' })
+            handleError(err)
+
+            expect(generalErrorRaw.value).toBe(err)
+        })
+
+        it('is set to the raw AxiosError for a no-response AxiosError', () => {
+            vi.spyOn(console, 'error').mockImplementation(() => {})
+            const { generalErrorRaw, handleError } = useApiErrors()
+
+            const err = new AxiosError('Network Error')
+            handleError(err)
+
+            expect(generalErrorRaw.value).toBe(err)
+        })
+
+        it('stays null for a 422 with field errors', () => {
+            const { generalErrorRaw, handleError } = useApiErrors()
+
+            handleError(makeAxiosError(422, { errors: { name: ['Required'] } }))
+
+            expect(generalErrorRaw.value).toBeNull()
+        })
+
+        it('stays null for a 422 with an empty errors object', () => {
+            const { generalErrorRaw, handleError } = useApiErrors()
+
+            handleError(makeAxiosError(422, { errors: {} }))
+
+            expect(generalErrorRaw.value).toBeNull()
+        })
+
+        it('stays null for an unparseable 422 body', () => {
+            vi.spyOn(console, 'error').mockImplementation(() => {})
+            const { generalErrorRaw, handleError } = useApiErrors()
+
+            handleError(makeAxiosError(422, null))
+
+            expect(generalErrorRaw.value).toBeNull()
+        })
+
+        it('is cleared by reset() after a non-422 failure', () => {
+            vi.spyOn(console, 'error').mockImplementation(() => {})
+            const { generalErrorRaw, handleError, reset } = useApiErrors()
+
+            handleError(makeAxiosError(500, { message: 'Server error' }))
+            expect(generalErrorRaw.value).not.toBeNull()
+
+            reset()
+
+            expect(generalErrorRaw.value).toBeNull()
+        })
+
+        it('is reset to null when a subsequent call is a 422', () => {
+            vi.spyOn(console, 'error').mockImplementation(() => {})
+            const { generalErrorRaw, handleError } = useApiErrors()
+
+            handleError(makeAxiosError(400, { message: 'Bad request' }))
+            expect(generalErrorRaw.value).not.toBeNull()
+
+            handleError(makeAxiosError(422, { errors: { name: ['Required'] } }))
+            expect(generalErrorRaw.value).toBeNull()
+        })
     })
 
     describe('known/unknown field split (knownFields option)', () => {

--- a/src/composables/useApiErrors.ts
+++ b/src/composables/useApiErrors.ts
@@ -15,10 +15,15 @@ export function useApiErrors(knownFields?: string[]) {
     const knownFieldSet = knownFields ? new Set(knownFields) : null
     const fieldErrors = ref<Record<string, string[]>>({})
     const generalError = ref<string | null>(null)
+    // Raw, unformatted error for non-422 failures — lets consumers (LoadErrorAlert) render a
+    // "Show details" breakdown. Stays null for every 422 branch, since those are user-facing
+    // validation messages, not failures worth a debug dump.
+    const generalErrorRaw = ref<unknown>(null)
 
     function reset(): void {
         fieldErrors.value = {}
         generalError.value = null
+        generalErrorRaw.value = null
     }
 
     function handleError(error: unknown): void {
@@ -27,6 +32,7 @@ export function useApiErrors(knownFields?: string[]) {
         if (!(error instanceof AxiosError) || !error.response) {
             console.error('[useApiErrors] non-HTTP error:', error)
             generalError.value = i18n.global.t('unknownError')
+            generalErrorRaw.value = error
             return
         }
 
@@ -69,7 +75,8 @@ export function useApiErrors(knownFields?: string[]) {
             console.error('[useApiErrors] HTTP error', status, parseError)
         }
         generalError.value = i18n.global.t('unknownError')
+        generalErrorRaw.value = error
     }
 
-    return { fieldErrors, generalError, reset, handleError }
+    return { fieldErrors, generalError, generalErrorRaw, reset, handleError }
 }

--- a/src/lang/messages/en.ts
+++ b/src/lang/messages/en.ts
@@ -70,6 +70,7 @@ export default {
     passkeySettings: {
         passkeys: 'Passkeys',
         yourPasskeys: 'Your Passkeys',
+        loadingError: 'Unable to load your passkeys. Please try again later.',
 
         featureSupports: 'Cash Track supports',
         featureSupportsPasskeys: 'Passkeys',
@@ -295,6 +296,7 @@ export default {
     emailConfirmRequired: 'Confirm your email to do this',
 
     limits: {
+        loadingError: 'Unable to load limits. Please try again later.',
         createLimit: 'Create Limit',
         copyFrom: 'Copy From',
         amount: 'Amount',

--- a/src/lang/messages/en.ts
+++ b/src/lang/messages/en.ts
@@ -292,7 +292,6 @@ export default {
         otherTags: 'Other {0} tags'
     },
 
-    retry: 'Retry',
     emailConfirmRequired: 'Confirm your email to do this',
 
     limits: {

--- a/src/lang/messages/uk.ts
+++ b/src/lang/messages/uk.ts
@@ -70,6 +70,7 @@ export default {
     passkeySettings: {
         passkeys: 'Ключі доступу',
         yourPasskeys: 'Ваші ключі',
+        loadingError: 'Не вдалося завантажити ваші ключі доступу. Будь ласка, спробуйте пізніше.',
 
         featureSupports: 'Cash Track підтримує',
         featureSupportsPasskeys: 'Ключі доступу (Passkeys)',
@@ -295,6 +296,7 @@ export default {
     emailConfirmRequired: 'Підтвердьте електронну пошту, щоб виконати цю дію',
 
     limits: {
+        loadingError: 'Не вдалося завантажити ліміти. Будь ласка, спробуйте пізніше.',
         createLimit: 'Створити ліміт',
         copyFrom: 'Скопіювати',
         amount: 'Сума',

--- a/src/lang/messages/uk.ts
+++ b/src/lang/messages/uk.ts
@@ -292,7 +292,6 @@ export default {
         otherTags: 'Інші {0} тег(ів)'
     },
 
-    retry: 'Повторити',
     emailConfirmRequired: 'Підтвердьте електронну пошту, щоб виконати цю дію',
 
     limits: {

--- a/src/views/TagView.vue
+++ b/src/views/TagView.vue
@@ -13,6 +13,7 @@ import ChargesFilter from '@/components/wallets/charges/ChargesFilter.vue'
 import ChargeItem from '@/components/wallets/charges/ChargeItem.vue'
 import TagChargesFlowChart from '@/components/wallets/charges/TagChargesFlowChart.vue'
 import WalletsActiveShortList from '@/components/wallets/WalletsActiveShortList.vue'
+import LoadErrorAlert from '@/components/Shared/LoadErrorAlert.vue'
 import { useChargesGrouping } from '@/composables/useChargesGrouping'
 
 const props = defineProps<{ tagID: string }>()
@@ -35,7 +36,9 @@ const loadingCharges = ref(true)
 const loadingCommonTags = ref(true)
 const loadingMore = ref(false)
 const errorTag = ref<string | null>(null)
+const lastErrorTag = ref<unknown>(null)
 const errorCharges = ref<string | null>(null)
+const lastErrorCharges = ref<unknown>(null)
 const currentPage = ref(1)
 const filter = ref<FilterState>({ dateFrom: '', dateTo: '' })
 const showFilters = ref(false)
@@ -47,12 +50,14 @@ const { chargesGrouped } = useChargesGrouping(charges, t, locale)
 async function loadTag() {
     loadingTag.value = true
     errorTag.value = null
+    lastErrorTag.value = null
     try {
         tag.value = await getTagById(selectedTagId.value)
         loadTotals()
         loadCharges(1)
-    } catch {
+    } catch (err) {
         errorTag.value = t('tags.statsLoadingError')
+        lastErrorTag.value = err
         loadingTotals.value = false
         loadingCharges.value = false
     } finally {
@@ -77,6 +82,7 @@ async function loadTotals() {
 async function loadCharges(page: number) {
     if (page === 1) loadingCharges.value = true
     errorCharges.value = null
+    lastErrorCharges.value = null
     try {
         const res = await getTagCharges(selectedTagId.value, {
             page,
@@ -90,7 +96,8 @@ async function loadCharges(page: number) {
         }
         pagination.value = res.pagination
         currentPage.value = page
-    } catch {
+    } catch (err) {
+        lastErrorCharges.value = err
         if (page === 1) {
             errorCharges.value = t('charges.loadingError')
             charges.value = []
@@ -229,11 +236,12 @@ onUnmounted(() => {
         </div>
 
         <!-- Tag load error -->
-        <UAlert
+        <LoadErrorAlert
             v-if="errorTag"
-            color="error"
-            :description="errorTag"
-            icon="i-lucide-alert-circle"
+            :title="errorTag"
+            :error="lastErrorTag"
+            retryable
+            @retry="loadTag()"
         />
 
         <USeparator />
@@ -288,23 +296,14 @@ onUnmounted(() => {
                 </div>
             </template>
             <template v-else>
-                <UAlert
+                <LoadErrorAlert
                     v-if="errorCharges"
-                    color="error"
-                    icon="i-lucide-alert-circle"
-                    :description="errorCharges"
+                    :title="errorCharges"
+                    :error="lastErrorCharges"
+                    retryable
                     class="mb-3"
+                    @retry="loadCharges(1)"
                 />
-                <div v-if="errorCharges" class="flex justify-center mt-2">
-                    <UButton
-                        variant="outline"
-                        color="neutral"
-                        size="md"
-                        @click="loadCharges(1)"
-                    >
-                        {{ t('retry') }}
-                    </UButton>
-                </div>
                 <template v-if="!errorCharges">
                     <template v-for="[group, groupCharges] in chargesGrouped" :key="group">
                         <!-- Day group header -->

--- a/src/views/TagsView.vue
+++ b/src/views/TagsView.vue
@@ -8,6 +8,7 @@ import TagComponent from '@/components/tags/Tag.vue'
 import CreateTag from '@/components/tags/CreateTag.vue'
 import TagForm from '@/components/tags/TagForm.vue'
 import ConfirmModal from '@/components/Shared/ConfirmModal.vue'
+import LoadErrorAlert from '@/components/Shared/LoadErrorAlert.vue'
 
 const { t } = useI18n()
 const router = useRouter()
@@ -15,6 +16,7 @@ const router = useRouter()
 const tags = ref<Tag[]>([])
 const loading = ref(false)
 const error = ref<string | null>(null)
+const lastError = ref<unknown>(null)
 
 const editingTag = ref<Tag | null>(null)
 const editModalOpen = ref(false)
@@ -27,10 +29,12 @@ const deleteError = ref<string | null>(null)
 async function loadTags() {
     loading.value = true
     error.value = null
+    lastError.value = null
     try {
         tags.value = await getTags()
-    } catch {
+    } catch (err) {
         error.value = t('tags.statsLoadingError')
+        lastError.value = err
     } finally {
         loading.value = false
     }
@@ -93,23 +97,13 @@ onMounted(loadTags)
         </div>
 
         <!-- Error -->
-        <template v-else-if="error">
-            <UAlert
-                color="error"
-                :description="error"
-                icon="i-lucide-alert-circle"
-            />
-            <div class="flex justify-center mt-2">
-                <UButton
-                    variant="outline"
-                    color="neutral"
-                    size="md"
-                    @click="loadTags()"
-                >
-                    {{ t('retry') }}
-                </UButton>
-            </div>
-        </template>
+        <LoadErrorAlert
+            v-else-if="error"
+            :title="error"
+            :error="lastError"
+            retryable
+            @retry="loadTags()"
+        />
 
         <template v-else>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/src/views/WalletEditView.vue
+++ b/src/views/WalletEditView.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import { getWallet } from '@/api/wallets'
 import type { Wallet } from '@/api/models/wallet'
 import WalletEdit from '@/components/wallets/WalletEdit.vue'
+import LoadErrorAlert from '@/components/Shared/LoadErrorAlert.vue'
 
 const props = defineProps<{ walletID: string }>()
 
@@ -11,17 +12,23 @@ const { t } = useI18n()
 const wallet = shallowRef<Wallet | null>(null)
 const loading = shallowRef(false)
 const error = shallowRef<string | null>(null)
+const lastError = shallowRef<unknown>(null)
 
-onMounted(async () => {
+async function load() {
     loading.value = true
+    error.value = null
+    lastError.value = null
     try {
         wallet.value = await getWallet(Number(props.walletID))
-    } catch {
+    } catch (err) {
         error.value = t('wallets.loadingError')
+        lastError.value = err
     } finally {
         loading.value = false
     }
-})
+}
+
+onMounted(load)
 </script>
 
 <template>
@@ -29,11 +36,12 @@ onMounted(async () => {
         <div v-if="loading" class="flex justify-center py-12">
             <UIcon name="i-lucide-loader-circle" class="size-8 animate-spin text-muted" />
         </div>
-        <UAlert
+        <LoadErrorAlert
             v-else-if="error"
-            color="error"
-            :description="error"
-            icon="i-lucide-alert-circle"
+            :title="error"
+            :error="lastError"
+            retryable
+            @retry="load()"
         />
         <WalletEdit v-else-if="wallet" :wallet="wallet" />
     </div>

--- a/src/views/WalletShareView.vue
+++ b/src/views/WalletShareView.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import { getWallet } from '@/api/wallets'
 import type { Wallet } from '@/api/models/wallet'
 import WalletShare from '@/components/wallets/WalletShare.vue'
+import LoadErrorAlert from '@/components/Shared/LoadErrorAlert.vue'
 
 const props = defineProps<{ walletID: string }>()
 
@@ -11,17 +12,23 @@ const { t } = useI18n()
 const wallet = shallowRef<Wallet | null>(null)
 const loading = shallowRef(false)
 const error = shallowRef<string | null>(null)
+const lastError = shallowRef<unknown>(null)
 
-onMounted(async () => {
+async function load() {
     loading.value = true
+    error.value = null
+    lastError.value = null
     try {
         wallet.value = await getWallet(Number(props.walletID))
-    } catch {
+    } catch (err) {
         error.value = t('wallets.loadingError')
+        lastError.value = err
     } finally {
         loading.value = false
     }
-})
+}
+
+onMounted(load)
 </script>
 
 <template>
@@ -29,11 +36,12 @@ onMounted(async () => {
         <div v-if="loading" class="flex justify-center py-12">
             <UIcon name="i-lucide-loader-circle" class="size-8 animate-spin text-muted" />
         </div>
-        <UAlert
+        <LoadErrorAlert
             v-else-if="error"
-            color="error"
-            :description="error"
-            icon="i-lucide-alert-circle"
+            :title="error"
+            :error="lastError"
+            retryable
+            @retry="load()"
         />
         <WalletShare v-else-if="wallet" :wallet="wallet" />
     </div>

--- a/src/views/WalletView.vue
+++ b/src/views/WalletView.vue
@@ -21,6 +21,7 @@ import ChargesTotalChart from '@/components/wallets/charges/ChargesTotalChart.vu
 import WalletLimitsTotal from '@/components/wallets/limits/WalletLimitsTotal.vue'
 import WalletsActiveShortList from '@/components/wallets/WalletsActiveShortList.vue'
 import MoneyAmount from '@/components/Shared/MoneyAmount.vue'
+import LoadErrorAlert from '@/components/Shared/LoadErrorAlert.vue'
 
 const props = defineProps<{ walletID: string }>()
 
@@ -35,6 +36,7 @@ const walletTags = ref<Tag[]>([])
 const selectedTags = ref<Tag[]>([])
 const loading = ref(false)
 const error = ref<string | null>(null)
+const lastError = ref<unknown>(null)
 
 const showCreateForm = ref(false)
 const showFilters = ref(false)
@@ -51,6 +53,7 @@ const limitsRef = ref<InstanceType<typeof WalletLimitsTotal> | null>(null)
 async function loadWallet() {
     loading.value = true
     error.value = null
+    lastError.value = null
 
     try {
         const walletId = Number(props.walletID)
@@ -64,8 +67,9 @@ async function loadWallet() {
         totals.value = tot
         users.value = u
         walletTags.value = tags
-    } catch {
+    } catch (err) {
         error.value = t('wallets.loadingError')
+        lastError.value = err
         wallet.value = null
         totals.value = null
         users.value = []
@@ -250,11 +254,12 @@ defineExpose({ wallet, error, showCreateForm, showFilters, showGraph, showLimits
         </div>
 
         <!-- Error with no previous content to fall back to -->
-        <UAlert
+        <LoadErrorAlert
             v-else-if="error && !wallet"
-            color="error"
-            :description="error"
-            icon="i-lucide-alert-circle"
+            :title="error"
+            :error="lastError"
+            retryable
+            @retry="loadWallet()"
         />
 
         <!-- Content: kept mounted while switching wallets so it never collapses -->

--- a/src/views/__tests__/TagsView.spec.ts
+++ b/src/views/__tests__/TagsView.spec.ts
@@ -56,6 +56,23 @@ const popoverStub = {
 
 const tagChipStub = { template: '<button data-testid="tag-chip"></button>', props: ['tag', 'navigable'] }
 
+// LoadErrorAlert stub that emits retry on button click
+const loadErrorAlertStub = {
+    name: 'LoadErrorAlert',
+    props: {
+        title: {},
+        error: {},
+        retryable: { type: Boolean, default: false },
+    },
+    emits: ['retry'],
+    template: `
+        <div class="load-error-alert-stub">
+            <span class="load-error-title">{{ title }}</span>
+            <button v-if="retryable" class="load-error-retry" @click="$emit('retry')">retry</button>
+        </div>
+    `,
+}
+
 const makeGlobal = () => ({
     global: {
         stubs: {
@@ -73,6 +90,7 @@ const makeGlobal = () => ({
             },
             UModal: { template: '<div><slot name="body" /></div>', props: ['open', 'title'] },
             UAlert: { template: '<div />', props: ['color', 'description', 'icon', 'variant'] },
+            LoadErrorAlert: loadErrorAlertStub,
             UIcon: { template: '<span />', props: ['name', 'class'] },
             Icon: { template: '<span />', props: ['name', 'class'] },
             USkeleton: { template: '<div />', props: ['class'] },
@@ -281,20 +299,17 @@ describe('TagsView.vue', () => {
         await nextTick()
         await nextTick()
 
-        // Error state: retry button must be visible
-        const text = wrapper.text()
-        expect(text).toContain('retry')
+        // Error state: LoadErrorAlert with a retry button must be visible
+        expect(wrapper.find('.load-error-alert-stub').exists()).toBe(true)
+        const retryBtn = wrapper.find('.load-error-retry')
+        expect(retryBtn.exists()).toBe(true)
 
         // Prepare a successful response for the retry
         const tag = makeTag({ id: 1, name: 'Food' })
         vi.mocked(getTags).mockResolvedValue([tag])
 
         // Click the retry button
-        const buttons = wrapper.findAll('button')
-        const retryBtn = buttons.find(b => b.text() === 'retry')
-        expect(retryBtn).toBeDefined()
-
-        await retryBtn!.trigger('click')
+        await retryBtn.trigger('click')
         await nextTick()
         await nextTick()
 

--- a/src/views/__tests__/WalletEditView.spec.ts
+++ b/src/views/__tests__/WalletEditView.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+import { mount, flushPromises } from '@vue/test-utils'
+import WalletEditView from '../WalletEditView.vue'
+import { Wallet } from '@/api/models/wallet'
+
+vi.mock('vue-i18n', () => ({
+    useI18n: () => ({
+        t: (key: string) => key,
+        locale: ref('en'),
+    }),
+    createI18n: () => ({
+        global: { t: (key: string) => key, locale: { value: 'en' }, setLocaleMessage: vi.fn() },
+    }),
+}))
+
+vi.mock('@/api/wallets', () => ({
+    getWallet: vi.fn(),
+}))
+
+import { getWallet } from '@/api/wallets'
+
+function makeWallet(id = 1): Wallet {
+    return new Wallet({
+        id,
+        name: 'Test Wallet',
+        slug: 'test-wallet',
+        totalAmount: 0,
+        isActive: true,
+        isPublic: false,
+        isArchived: false,
+        defaultCurrencyCode: 'USD',
+        defaultCurrency: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        users: [],
+        latestCharges: [],
+    })
+}
+
+const globalStubs = {
+    props: { walletID: '1' },
+    global: {
+        stubs: {
+            WalletEdit: { template: '<div class="wallet-edit-stub" />', props: ['wallet'] },
+            UIcon: true,
+        },
+    },
+}
+
+describe('WalletEditView.vue', () => {
+    beforeEach(() => {
+        vi.mocked(getWallet).mockReset()
+    })
+
+    it('renders WalletEdit once the wallet loads', async () => {
+        vi.mocked(getWallet).mockResolvedValue(makeWallet())
+
+        const wrapper = mount(WalletEditView, globalStubs)
+        await flushPromises()
+
+        expect(wrapper.find('.wallet-edit-stub').exists()).toBe(true)
+        expect(wrapper.findComponent({ name: 'LoadErrorAlert' }).exists()).toBe(false)
+    })
+
+    it('shows a retryable LoadErrorAlert on load failure, and reloads on retry', async () => {
+        vi.mocked(getWallet).mockRejectedValueOnce(new Error('network error'))
+
+        const wrapper = mount(WalletEditView, globalStubs)
+        await flushPromises()
+
+        const alert = wrapper.findComponent({ name: 'LoadErrorAlert' })
+        expect(alert.exists()).toBe(true)
+        expect(alert.props('retryable')).toBe(true)
+        expect(wrapper.find('.wallet-edit-stub').exists()).toBe(false)
+
+        vi.mocked(getWallet).mockResolvedValue(makeWallet())
+
+        await alert.vm.$emit('retry')
+        await flushPromises()
+
+        expect(wrapper.findComponent({ name: 'LoadErrorAlert' }).exists()).toBe(false)
+        expect(wrapper.find('.wallet-edit-stub').exists()).toBe(true)
+    })
+})

--- a/src/views/__tests__/WalletShareView.spec.ts
+++ b/src/views/__tests__/WalletShareView.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+import { mount, flushPromises } from '@vue/test-utils'
+import WalletShareView from '../WalletShareView.vue'
+import { Wallet } from '@/api/models/wallet'
+
+vi.mock('vue-i18n', () => ({
+    useI18n: () => ({
+        t: (key: string) => key,
+        locale: ref('en'),
+    }),
+    createI18n: () => ({
+        global: { t: (key: string) => key, locale: { value: 'en' }, setLocaleMessage: vi.fn() },
+    }),
+}))
+
+vi.mock('@/api/wallets', () => ({
+    getWallet: vi.fn(),
+}))
+
+import { getWallet } from '@/api/wallets'
+
+function makeWallet(id = 1): Wallet {
+    return new Wallet({
+        id,
+        name: 'Test Wallet',
+        slug: 'test-wallet',
+        totalAmount: 0,
+        isActive: true,
+        isPublic: false,
+        isArchived: false,
+        defaultCurrencyCode: 'USD',
+        defaultCurrency: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        users: [],
+        latestCharges: [],
+    })
+}
+
+const globalStubs = {
+    props: { walletID: '1' },
+    global: {
+        stubs: {
+            WalletShare: { template: '<div class="wallet-share-stub" />', props: ['wallet'] },
+            UIcon: true,
+        },
+    },
+}
+
+describe('WalletShareView.vue', () => {
+    beforeEach(() => {
+        vi.mocked(getWallet).mockReset()
+    })
+
+    it('renders WalletShare once the wallet loads', async () => {
+        vi.mocked(getWallet).mockResolvedValue(makeWallet())
+
+        const wrapper = mount(WalletShareView, globalStubs)
+        await flushPromises()
+
+        expect(wrapper.find('.wallet-share-stub').exists()).toBe(true)
+        expect(wrapper.findComponent({ name: 'LoadErrorAlert' }).exists()).toBe(false)
+    })
+
+    it('shows a retryable LoadErrorAlert on load failure, and reloads on retry', async () => {
+        vi.mocked(getWallet).mockRejectedValueOnce(new Error('network error'))
+
+        const wrapper = mount(WalletShareView, globalStubs)
+        await flushPromises()
+
+        const alert = wrapper.findComponent({ name: 'LoadErrorAlert' })
+        expect(alert.exists()).toBe(true)
+        expect(alert.props('retryable')).toBe(true)
+        expect(wrapper.find('.wallet-share-stub').exists()).toBe(false)
+
+        vi.mocked(getWallet).mockResolvedValue(makeWallet())
+
+        await alert.vm.$emit('retry')
+        await flushPromises()
+
+        expect(wrapper.findComponent({ name: 'LoadErrorAlert' }).exists()).toBe(false)
+        expect(wrapper.find('.wallet-share-stub').exists()).toBe(true)
+    })
+})

--- a/src/views/__tests__/WalletView.spec.ts
+++ b/src/views/__tests__/WalletView.spec.ts
@@ -183,6 +183,29 @@ describe('WalletView.vue', () => {
         expect(wrapper.findComponent(WalletHeader as Parameters<typeof wrapper.findComponent>[0]).exists()).toBe(false)
     })
 
+    it('shows a retryable LoadErrorAlert on load failure, and reloads on retry', async () => {
+        vi.mocked(getWallet).mockRejectedValueOnce(new Error('network error'))
+
+        const wrapper = mount(WalletView, makeGlobal())
+        await flushAll()
+
+        const alert = wrapper.findComponent({ name: 'LoadErrorAlert' })
+        expect(alert.exists()).toBe(true)
+        expect(alert.props('retryable')).toBe(true)
+
+        vi.mocked(getWallet).mockResolvedValue(makeWallet())
+        const callsBeforeRetry = vi.mocked(getWallet).mock.calls.length
+
+        await alert.vm.$emit('retry')
+        await flushAll()
+
+        expect(vi.mocked(getWallet).mock.calls.length).toBe(callsBeforeRetry + 1)
+        expect(wrapper.findComponent({ name: 'LoadErrorAlert' }).exists()).toBe(false)
+        const vm = wrapper.vm as unknown as { wallet: Wallet | null; error: string | null }
+        expect(vm.wallet).not.toBeNull()
+        expect(vm.error).toBeNull()
+    })
+
     describe('charge title autocomplete overflow override (issue #110)', () => {
         // WalletView.vue's <UCollapsible> tags resolve at runtime to the global
         // stub keyed 'Collapsible' (not 'UCollapsible') — verified empirically:


### PR DESCRIPTION
## Problem

Only the active-wallets and profile loads used `LoadErrorAlert` with its Show details and Retry actions. Every other non-422 error rendered as a bare generic message: no way to see what actually failed, and load failures offered no recovery path beyond a full page reload. Two loads (limits total, passkeys) failed completely silently.

## Changes

- `LoadErrorAlert` gains an optional `retryable` prop (default off) and becomes the single error alert component. Every non-422 error now offers a Show details toggle rendering structured, metadata-only error details; GET/load failures additionally offer Retry, wired to re-fire the load. Form submissions (mutations) never show Retry. The four pre-existing call sites keep their behaviour.
- `useApiErrors` exposes `generalErrorRaw`, set only on non-422 paths, so forms distinguish validation copy (plain alert, unchanged) from real errors (details-capable alert). All nine forms are wired accordingly.
- Fifteen load sites converted to `LoadErrorAlert` with Retry: wallets lists, charges list and all three charts, limits total, passkeys, tags views, wallet detail/edit/share views, latest wallets, and the app-level profile load. The two previously silent failures now surface visibly.
- `WalletShare` invite failures show one specific inline alert (with details) instead of a fixed toast; stale errors reset on each attempt.
- i18n: two new keys in both locales; full key-set parity verified (261/261).

Stacked on #120. Closes #116.

## Verification

- Independent code review across the full diff: no material findings; i18n parity diffed programmatically; a focused re-review of the WalletShare change caught a stale-error edge case (failed invite followed by successful retry), fixed with regression coverage.
- `npm run type-check` clean, `npm run lint` 0 errors, Vitest suite 81 files / 658 tests green, including three new spec files for previously uncovered components (LimitForm, WalletEditView, WalletShareView).
- Full Playwright suite against the local stack: 186 passed, 2 documented WebAuthn skips, 2 non-reproducing timeouts under serial load that passed clean on isolated re-run. New/updated E2E cases cover Retry + Show details on load failure, form 500 showing details without Retry, and the rewritten WalletShare invite-error case with the error-leak guard kept active.
