### PR TITLE
feat(frontend): add automatic theme mode with resolved-theme indicator

### DIFF
--- a/e2e/i18n-theme.spec.ts
+++ b/e2e/i18n-theme.spec.ts
@@ -4,8 +4,9 @@
  * IT-01  Locale switch updates in-page UI labels
  * IT-02  Locale persists after page reload (cshtrkl cookie)
  * IT-03  Switching locale calls PUT /api/profile/locale (updateLocale)
- * IT-04  Dark mode persists after reload (localStorage)
+ * IT-04  Theme menu: selecting Light/Dark pins html.dark and persists after reload (localStorage)
  * IT-05  Document titles for each route (static meta.title; namedTitle is dead code — see NAV-09)
+ * IT-06  Theme menu: selecting System follows prefers-color-scheme live and persists 'auto'
  *
  * Notes:
  * - NEVER click Sign Out (kills shared session).
@@ -16,6 +17,13 @@
  * - The app detects locale from cshtrkl cookie on mount, then overrides it from
  *   GET /api/profile response (profile.store.ts sets localeChange(user.locale)).
  *   So we detect the active locale from document.documentElement.lang, not the cookie.
+ * - The theme trigger (shell.darkModeToggle) opens a Light/Dark/System UDropdownMenu
+ *   (AppHeader.vue) — it no longer flips the mode directly on click. Pick the target
+ *   option via shell.themeMenuItem(page, choice). Its aria-label stays static
+ *   ("theme.theme") regardless of the current mode — only the icon changes.
+ * - In System mode the trigger renders a composite icon (resolved sun/moon + a small
+ *   monitor corner badge) — 2 <svg> nodes inside the trigger vs 1 for a manual pin.
+ *   IT-06 asserts this count as a cheap, stable proxy for "the badge is showing."
  */
 import { test, expect } from '@playwright/test'
 import {
@@ -240,7 +248,7 @@ test.describe('S22 — i18n, dark mode, document titles', () => {
 
     // IT-04 ───────────────────────────────────────────────────────────────────
     test(
-        'IT-04 @smoke dark mode toggle persists html.dark after reload',
+        'IT-04 @smoke theme menu: selecting Light/Dark pins html.dark and persists after reload',
         async ({ page }) => {
             await page.goto('/wallets')
 
@@ -248,9 +256,11 @@ test.describe('S22 — i18n, dark mode, document titles', () => {
             const isInitiallyDark = await page.evaluate(() =>
                 document.documentElement.classList.contains('dark'),
             )
+            const targetChoice: 'light' | 'dark' = isInitiallyDark ? 'light' : 'dark'
 
-            // Toggle once → mode flips
+            // Open the theme menu and pin the opposite mode explicitly.
             await shell.darkModeToggle(page).click()
+            await shell.themeMenuItem(page, targetChoice).click()
             await expect
                 .poll(
                     () => page.evaluate(() => document.documentElement.classList.contains('dark')),
@@ -258,8 +268,8 @@ test.describe('S22 — i18n, dark mode, document titles', () => {
                 )
                 .toBe(!isInitiallyDark)
 
-            // Reload → localStorage restores mode (VueUse colorMode). Poll: the html.dark class
-            // is reapplied on mount, which can land just after domcontentloaded.
+            // Reload → localStorage restores the pinned mode (VueUse colorMode). Poll: the
+            // html.dark class is reapplied on mount, which can land just after domcontentloaded.
             await page.reload()
             await page.waitForLoadState('domcontentloaded')
             await expect
@@ -268,9 +278,17 @@ test.describe('S22 — i18n, dark mode, document titles', () => {
                     { timeout: 5000 },
                 )
                 .toBe(!isInitiallyDark)
+            await expect
+                .poll(
+                    () => page.evaluate(() => localStorage.getItem('vueuse-color-scheme')),
+                    { timeout: 5000 },
+                )
+                .toBe(targetChoice)
 
             // Restore original mode (per-context so harmless, but good practice)
+            const restoreChoice: 'light' | 'dark' = isInitiallyDark ? 'dark' : 'light'
             await shell.darkModeToggle(page).click()
+            await shell.themeMenuItem(page, restoreChoice).click()
             await expect
                 .poll(
                     () => page.evaluate(() => document.documentElement.classList.contains('dark')),
@@ -323,6 +341,82 @@ test.describe('S22 — i18n, dark mode, document titles', () => {
             } finally {
                 await deleteWalletViaApi(request, seeded.id)
             }
+        },
+    )
+
+    // IT-06 ───────────────────────────────────────────────────────────────────
+    test(
+        'IT-06 theme menu: selecting System follows prefers-color-scheme live and persists auto',
+        async ({ page }) => {
+            // Pin the OS-level scheme so the assertions below are deterministic.
+            await page.emulateMedia({ colorScheme: 'light' })
+            await page.goto('/wallets')
+
+            await shell.darkModeToggle(page).click()
+            await shell.themeMenuItem(page, 'system').click()
+
+            // Selecting System writes 'auto' to the VueUse colorMode storage key…
+            await expect
+                .poll(
+                    () => page.evaluate(() => localStorage.getItem('vueuse-color-scheme')),
+                    { timeout: 5000 },
+                )
+                .toBe('auto')
+            // …and immediately follows the (emulated) device scheme.
+            await expect
+                .poll(
+                    () => page.evaluate(() => document.documentElement.classList.contains('dark')),
+                    { timeout: 5000 },
+                )
+                .toBe(false)
+
+            // The trigger renders a composite icon in System mode: the resolved sun/moon glyph
+            // plus a small monitor corner badge — 2 icon/svg nodes, vs 1 for a manual pin.
+            // Cheap, stable proxy for "the badge is showing" without asserting internal classes.
+            await expect
+                .poll(
+                    () => shell.darkModeToggle(page).locator('svg').count(),
+                    { timeout: 5000 },
+                )
+                .toBe(2)
+
+            // Flip the OS-level scheme without reloading — System mode must follow live.
+            await page.emulateMedia({ colorScheme: 'dark' })
+            await expect
+                .poll(
+                    () => page.evaluate(() => document.documentElement.classList.contains('dark')),
+                    { timeout: 5000 },
+                )
+                .toBe(true)
+
+            await page.emulateMedia({ colorScheme: 'light' })
+            await expect
+                .poll(
+                    () => page.evaluate(() => document.documentElement.classList.contains('dark')),
+                    { timeout: 5000 },
+                )
+                .toBe(false)
+
+            // Restore to an explicit pin (per-context so harmless, but good practice — avoids
+            // leaving the page on a mode that depends on the runner's emulated scheme).
+            await shell.darkModeToggle(page).click()
+            await shell.themeMenuItem(page, 'light').click()
+            await expect
+                .poll(
+                    () => page.evaluate(() => localStorage.getItem('vueuse-color-scheme')),
+                    { timeout: 5000 },
+                )
+                .toBe('light')
+
+            // Manual pin: back down to a single icon/svg node — no monitor badge.
+            await expect
+                .poll(
+                    () => shell.darkModeToggle(page).locator('svg').count(),
+                    { timeout: 5000 },
+                )
+                .toBe(1)
+
+            await assertNoErrorLeak(page)
         },
     )
 })

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -132,16 +132,19 @@ test.describe('S1 — Navigation & App Shell', () => {
     })
 
     // NAV-07 ──────────────────────────────────────────────────────────────────
-    test('NAV-07 dark-mode toggle flips html.dark and persists after reload', async ({ page }) => {
+    test('NAV-07 theme menu: Light/Dark selection flips html.dark and persists after reload', async ({ page }) => {
         await page.goto('/wallets')
 
         // Detect the current mode before touching anything
         const isInitiallyDark = await page.evaluate(() =>
             document.documentElement.classList.contains('dark'),
         )
+        const targetChoice: 'light' | 'dark' = isInitiallyDark ? 'light' : 'dark'
 
-        // Toggle once; VueUse colorMode updates html.dark and writes to localStorage
+        // Open the theme menu and pin the opposite mode; VueUse colorMode updates html.dark
+        // and writes to localStorage.
         await shell.darkModeToggle(page).click()
+        await shell.themeMenuItem(page, targetChoice).click()
         await expect
             .poll(
                 () => page.evaluate(() => document.documentElement.classList.contains('dark')),
@@ -161,7 +164,9 @@ test.describe('S1 — Navigation & App Shell', () => {
             .toBe(!isInitiallyDark)
 
         // Restore original mode so we don't leave the context permanently dark/light
+        const restoreChoice: 'light' | 'dark' = isInitiallyDark ? 'dark' : 'light'
         await shell.darkModeToggle(page).click()
+        await shell.themeMenuItem(page, restoreChoice).click()
         await expect
             .poll(
                 () => page.evaluate(() => document.documentElement.classList.contains('dark')),

--- a/e2e/support/selectors.ts
+++ b/e2e/support/selectors.ts
@@ -3,9 +3,12 @@
 // EN|UK via label()/labelExact(), so it works in either account locale.
 //
 // Rule of thumb: role > label > test-id > CSS. Icon-only buttons carry i18n
-// aria-labels (darkMode, language, wallets.moreActions, …) — target role + label.
+// aria-labels (theme.theme, language, wallets.moreActions, …) — target role + label.
 import type { Locator, Page } from '@playwright/test'
 import { label, labelExact } from './i18n'
+
+/** Light/Dark/System, matching the values written to `mode.value` in AppHeader.vue. */
+export type ThemeChoice = 'light' | 'dark' | 'system'
 
 // ── App shell / header (AppHeader.vue) ───────────────────────────────────--
 export const shell = {
@@ -13,7 +16,10 @@ export const shell = {
     navWallets: (page: Page): Locator => page.getByRole('link', { name: label('wallets.wallets') }),
     navTags: (page: Page): Locator => page.getByRole('link', { name: label('tags.tags') }),
     navProfile: (page: Page): Locator => page.getByRole('link', { name: label('profile.profile') }),
-    darkModeToggle: (page: Page): Locator => page.getByRole('button', { name: label('darkMode') }),
+    // Opens the Light / Dark / System theme menu (see themeMenuItem below).
+    darkModeToggle: (page: Page): Locator => page.getByRole('button', { name: label('theme.theme') }),
+    themeMenuItem: (page: Page, choice: ThemeChoice): Locator =>
+        page.getByRole('menuitemcheckbox', { name: label(`theme.${choice}`) }),
     languageToggle: (page: Page): Locator => page.getByRole('button', { name: label('language') }),
     signOutItem: (page: Page): Locator => page.getByRole('menuitem', { name: label('signOut') }),
     settingsItem: (page: Page): Locator => page.getByRole('menuitem', { name: labelExact('settings') }),

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -56,6 +56,43 @@ function onLocaleChange(changed: LocaleInterface) {
     localeStore.localeChange(changed.code)
 }
 
+type ThemeChoice = 'light' | 'dark' | 'auto'
+
+const themeChoices: { value: ThemeChoice; labelKey: string; icon: string }[] = [
+    { value: 'light', labelKey: 'theme.light', icon: 'i-lucide-sun' },
+    { value: 'dark', labelKey: 'theme.dark', icon: 'i-lucide-moon' },
+    { value: 'auto', labelKey: 'theme.system', icon: 'i-lucide-monitor' },
+]
+
+const isSystemTheme = computed(() => mode.store.value === 'auto')
+
+// mode.value resolves 'auto' down to the live device scheme (light/dark) and is reactive
+// to prefers-color-scheme changes; for manual light/dark it's the same as mode.store.value.
+// Drives the trigger's main glyph — the monitor badge (below, in the template) marks the
+// auto/system case on top of it.
+const resolvedThemeIcon = computed(() => (mode.value === 'dark' ? 'i-lucide-moon' : 'i-lucide-sun'))
+
+const themeMenuItems = computed<DropdownMenuItem[][]>(() => {
+    return [
+        themeChoices.map<DropdownMenuItem>(choice => {
+            return {
+                label: t(choice.labelKey),
+                icon: choice.icon,
+                type: 'checkbox',
+                checked: mode.store.value === choice.value,
+                class: 'cursor-pointer',
+                onSelect() {
+                    onThemeChange(choice.value)
+                },
+            }
+        }),
+    ]
+})
+
+function onThemeChange(choice: ThemeChoice) {
+    mode.value = choice
+}
+
 watch(locale, (newLocale) => {
     loadLocaleAsync(newLocale)
 
@@ -178,14 +215,28 @@ function onLogout() {
                                 </ul>
                             </div>
                             <div class="flex justify-start flex-col md:justify-end md:flex-row">
-                                <UButton
-                                    :icon="mode === 'dark' ? 'i-lucide-moon' : 'i-lucide-sun'"
-                                    color="neutral"
-                                    variant="subtle"
-                                    :aria-label="t('darkMode')"
-                                    @click="mode = mode === 'dark' ? 'light' : 'dark'"
-                                    class="mr-4 ring-0 cursor-pointer"
-                                />
+                                <UDropdownMenu
+                                    class="mr-4 ring-0"
+                                    :items="themeMenuItems"
+                                    :content="{ side: 'bottom', align: 'start' }"
+                                >
+                                    <UButton
+                                        color="neutral"
+                                        variant="subtle"
+                                        :square="true"
+                                        :aria-label="t('theme.theme')"
+                                        class="cursor-pointer"
+                                    >
+                                        <span class="relative inline-flex size-5">
+                                            <UIcon :name="resolvedThemeIcon" class="size-5" />
+                                            <UIcon
+                                                v-if="isSystemTheme"
+                                                name="i-lucide-monitor"
+                                                class="absolute -right-[3px] -bottom-[3px] size-2.5 bg-gray-100 dark:bg-gray-800"
+                                            />
+                                        </span>
+                                    </UButton>
+                                </UDropdownMenu>
                                 <UDropdownMenu
                                     class="mr-4 text-xl ring-0"
                                     :items="availableLocales"

--- a/src/components/__tests__/AppHeader.spec.ts
+++ b/src/components/__tests__/AppHeader.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { ref, reactive, nextTick } from 'vue'
+import { ref, computed, reactive, nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import AppHeader from '../AppHeader.vue'
@@ -22,11 +22,32 @@ vi.mock('vue-router', () => ({
 // Mutable matchMedia state so tests can simulate desktop (md+) vs mobile viewports.
 const mediaState = vi.hoisted(() => ({ matches: false }))
 
+// Mutable color-mode "stored preference" (mode.store.value) plus the "resolved" device
+// scheme (mode.value when store === 'auto') so tests can simulate all 4 trigger states:
+// manual light, manual dark, auto+resolved-light, auto+resolved-dark. Mirrors VueUse's
+// real useColorMode() shape: a writable ref whose setter feeds back into `.store`, plus
+// a `.store` ref exposing the raw stored value (unlike `.value`, which VueUse resolves
+// 'auto' down to the live system light/dark).
+const colorModeState = vi.hoisted(() => ({
+    store: 'light' as 'light' | 'dark' | 'auto',
+    resolved: 'light' as 'light' | 'dark',
+}))
+
 vi.mock('@vueuse/core', async importOriginal => {
     const actual = await importOriginal<typeof import('@vueuse/core')>()
     return {
         ...actual,
-        useColorMode: () => ref('light'),
+        useColorMode: () => {
+            const store = ref(colorModeState.store)
+            const resolved = ref(colorModeState.resolved)
+            return Object.assign(
+                computed({
+                    get: () => (store.value === 'auto' ? resolved.value : store.value),
+                    set: v => { store.value = v },
+                }),
+                { store },
+            )
+        },
         useMediaQuery: () => ({ value: mediaState.matches }),
     }
 })
@@ -58,6 +79,8 @@ describe('AppHeader', () => {
         setActivePinia(createPinia())
         mockRoute.fullPath = '/'
         mediaState.matches = false
+        colorModeState.store = 'light'
+        colorModeState.resolved = 'light'
     })
 
     function mountHeader() {
@@ -142,10 +165,98 @@ describe('AppHeader', () => {
         expect(trigger.attributes('aria-controls')).toBe('app-header-menu')
     })
 
-    it('dark-mode toggle button has aria-label set to darkMode i18n key', () => {
+    it('theme toggle button has aria-label set to theme.theme i18n key', () => {
         const wrapper = mountHeader()
-        const btn = wrapper.find('[aria-label="darkMode"]')
+        const btn = wrapper.find('[aria-label="theme.theme"]')
         expect(btn.exists()).toBe(true)
+    })
+
+    it('theme trigger: stored light -> resolved icon is sun, no system badge', () => {
+        colorModeState.store = 'light'
+        const wrapper = mountHeader()
+        const vm = wrapper.vm as unknown as { resolvedThemeIcon: string; isSystemTheme: boolean }
+        expect(vm.resolvedThemeIcon).toBe('i-lucide-sun')
+        expect(vm.isSystemTheme).toBe(false)
+    })
+
+    it('theme trigger: stored dark -> resolved icon is moon, no system badge', () => {
+        colorModeState.store = 'dark'
+        const wrapper = mountHeader()
+        const vm = wrapper.vm as unknown as { resolvedThemeIcon: string; isSystemTheme: boolean }
+        expect(vm.resolvedThemeIcon).toBe('i-lucide-moon')
+        expect(vm.isSystemTheme).toBe(false)
+    })
+
+    it('theme trigger: stored auto + resolved light -> sun icon with system badge shown', () => {
+        colorModeState.store = 'auto'
+        colorModeState.resolved = 'light'
+        const wrapper = mountHeader()
+        const vm = wrapper.vm as unknown as { resolvedThemeIcon: string; isSystemTheme: boolean }
+        expect(vm.resolvedThemeIcon).toBe('i-lucide-sun')
+        expect(vm.isSystemTheme).toBe(true)
+    })
+
+    it('theme trigger: stored auto + resolved dark -> moon icon with system badge shown', () => {
+        colorModeState.store = 'auto'
+        colorModeState.resolved = 'dark'
+        const wrapper = mountHeader()
+        const vm = wrapper.vm as unknown as { resolvedThemeIcon: string; isSystemTheme: boolean }
+        expect(vm.resolvedThemeIcon).toBe('i-lucide-moon')
+        expect(vm.isSystemTheme).toBe(true)
+    })
+
+    it('theme menu exposes Light/Dark/System checkbox items with the stored one checked', () => {
+        colorModeState.store = 'dark'
+        const wrapper = mountHeader()
+        const vm = wrapper.vm as unknown as {
+            themeMenuItems: { label: string; type?: string; checked?: boolean }[][]
+        }
+        const items = vm.themeMenuItems[0]
+        expect(items.map(i => i.label)).toEqual(['theme.light', 'theme.dark', 'theme.system'])
+        expect(items.every(i => i.type === 'checkbox')).toBe(true)
+        expect(items.find(i => i.label === 'theme.dark')?.checked).toBe(true)
+        expect(items.find(i => i.label === 'theme.light')?.checked).toBe(false)
+        expect(items.find(i => i.label === 'theme.system')?.checked).toBe(false)
+    })
+
+    it('selecting System (auto) restores automatic mode and shows the system badge', async () => {
+        colorModeState.store = 'light'
+        colorModeState.resolved = 'light'
+        const wrapper = mountHeader()
+        const vm = wrapper.vm as unknown as {
+            resolvedThemeIcon: string
+            isSystemTheme: boolean
+            themeMenuItems: { label: string; checked?: boolean; onSelect?: () => void }[][]
+        }
+        expect(vm.resolvedThemeIcon).toBe('i-lucide-sun')
+        expect(vm.isSystemTheme).toBe(false)
+
+        vm.themeMenuItems[0].find(i => i.label === 'theme.system')?.onSelect?.()
+        await nextTick()
+
+        // Resolves through the mocked 'resolved' (device) scheme, still light here —
+        // only the system badge switches, per the composite icon design.
+        expect(vm.resolvedThemeIcon).toBe('i-lucide-sun')
+        expect(vm.isSystemTheme).toBe(true)
+        // The menu re-renders with System checked and Light no longer checked.
+        expect(vm.themeMenuItems[0].find(i => i.label === 'theme.system')?.checked).toBe(true)
+        expect(vm.themeMenuItems[0].find(i => i.label === 'theme.light')?.checked).toBe(false)
+    })
+
+    it('selecting Dark pins the dark preference and hides the system badge', async () => {
+        colorModeState.store = 'auto'
+        colorModeState.resolved = 'light'
+        const wrapper = mountHeader()
+        const vm = wrapper.vm as unknown as {
+            resolvedThemeIcon: string
+            isSystemTheme: boolean
+            themeMenuItems: { label: string; onSelect?: () => void }[][]
+        }
+        vm.themeMenuItems[0].find(i => i.label === 'theme.dark')?.onSelect?.()
+        await nextTick()
+
+        expect(vm.resolvedThemeIcon).toBe('i-lucide-moon')
+        expect(vm.isSystemTheme).toBe(false)
     })
 
     it('language selector button has aria-label set to language i18n key', () => {

--- a/src/lang/messages/en.ts
+++ b/src/lang/messages/en.ts
@@ -144,7 +144,12 @@ export default {
     },
 
     actions: 'Actions',
-    darkMode: 'Toggle dark mode',
+    theme: {
+        theme: 'Theme',
+        light: 'Light',
+        dark: 'Dark',
+        system: 'System',
+    },
     language: 'Select language',
 
     wallets: {

--- a/src/lang/messages/uk.ts
+++ b/src/lang/messages/uk.ts
@@ -144,7 +144,12 @@ export default {
     },
 
     actions: 'Дії',
-    darkMode: 'Перемкнути темний режим',
+    theme: {
+        theme: 'Тема',
+        light: 'Світла',
+        dark: 'Темна',
+        system: 'Системна',
+    },
     language: 'Обрати мову',
 
     wallets: {


### PR DESCRIPTION
## Problem

The header dark-mode control was a two-state sun/moon toggle that only ever wrote `light`/`dark` to localStorage. The default automatic (follow-device) behaviour was permanently lost after the first manual toggle — there was no way back to it.

Closes #118

## Changes

- Replaced the toggle with a three-choice dropdown — **Light / Dark / System** — following the pattern of the adjacent locale dropdown; the active choice is shown checked.
- Selecting System writes `auto` (VueUse `useColorMode`), so the app follows `prefers-color-scheme` again and live-updates when the device scheme changes.
- In System mode the trigger shows the **resolved** theme icon (sun/moon) with a small monitor badge in the corner, making both "automatic" and the current theme visible at a glance; manual modes keep the plain sun/moon icons.
- New `theme.*` i18n keys in EN and UK (replacing the old `darkMode` key), full key parity.
- Tests: unit coverage for all trigger states and menu behaviour; E2E IT-04 rewritten for the dropdown, new IT-06 proves System mode live-follows the device scheme (`emulateMedia`) and persists `auto`; NAV-07 and shared selectors updated.

## Verification

- Vitest 615/615 (78 files); `vue-tsc` type-check 0 errors; ESLint/Oxlint 0 errors.
- Playwright (`i18n-theme.spec.ts`, `navigation.spec.ts`, chromium, against the dev stack): 16/16.
- Independent review rounds: no material findings (`useColorMode` store/write semantics verified against the installed VueUse source; EN/UK key sets diffed).
- Live browser checks: Light/Dark pin and persist across reload; System restores auto-follow and reacts to device scheme changes; EN/UK labels verified; control usable in the mobile collapsed header; no console errors or error toasts.