### PR TITLE
feat(frontend): display release tag and commit sha in footer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,13 @@ RUN npm run build
 # production stage
 FROM nginx:stable-alpine AS production-stage
 
+# Release metadata, injected by entrypoint.sh into the SPA at container start (never
+# baked into the Vite build — config is deliberately resolved at runtime, see env.ts).
+ARG GIT_TAG=""
+ARG GIT_COMMIT=""
+ENV VITE_APP_VERSION=${GIT_TAG}
+ENV VITE_APP_COMMIT=${GIT_COMMIT}
+
 COPY --from=build-stage /app/dist /usr/share/nginx/html
 
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ IMAGE_LATEST=$(REPO):latest
 .PHONY: build tag push start stop
 
 build:
-	docker build . -t $(IMAGE_DEV)
+	docker build . -t $(IMAGE_DEV) --build-arg GIT_TAG=$(RELEASE_VERSION) --build-arg GIT_COMMIT=$(shell git rev-parse HEAD)
 
 tag:
 	docker tag $(IMAGE_DEV) $(IMAGE_RELEASE)

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -11,6 +11,7 @@
  * NAV-08  Language dropdown switches locale; cshtrkl cookie set; UI labels change
  * NAV-09  Title guard: router.push with nameForTitle sets namedTitle
  * NAV-10  Unknown path /nope — no crash, app shell still present
+ * NAV-11  Footer degrades gracefully when no release version/commit vars are configured
  */
 import { test, expect } from '@playwright/test'
 import {
@@ -329,6 +330,26 @@ test.describe('S1 — Navigation & App Shell', () => {
             // Title is non-empty (inherited from whatever was set before, or the default)
             const title = await page.title()
             expect(title.length).toBeGreaterThan(0)
+        },
+    )
+
+    // NAV-11 ──────────────────────────────────────────────────────────────────
+    test(
+        'NAV-11 footer degrades gracefully when no release version/commit vars are configured',
+        async ({ page }) => {
+            // The dev stack never sets VITE_APP_VERSION / VITE_APP_COMMIT (those are baked
+            // in only by the production Docker image via GIT_TAG/GIT_COMMIT build args), so
+            // this is the one state this suite can honestly exercise: plain copyright line,
+            // no "·" separator, no release/commit link. See AppFooter.spec.ts (unit) for the
+            // tag+sha / sha-only rendering, which requires injecting window.__APP_CONFIG__.
+            await page.goto('/wallets')
+
+            const footer = shell.footer(page)
+            await expect(footer).toContainText('Cash Track')
+            await expect(footer).not.toContainText('·')
+            await expect(footer.locator('a[href*="github.com/cash-track/frontend"]')).toHaveCount(0)
+
+            await assertNoErrorLeak(page)
         },
     )
 })

--- a/e2e/support/selectors.ts
+++ b/e2e/support/selectors.ts
@@ -10,8 +10,9 @@ import { label, labelExact } from './i18n'
 /** Light/Dark/System, matching the values written to `mode.value` in AppHeader.vue. */
 export type ThemeChoice = 'light' | 'dark' | 'system'
 
-// ── App shell / header (AppHeader.vue) ───────────────────────────────────--
+// ── App shell / header (AppHeader.vue) + footer (AppFooter.vue) ──────────--
 export const shell = {
+    footer: (page: Page): Locator => page.locator('footer'),
     hamburger: (page: Page): Locator => page.locator('[aria-controls="app-header-menu"]'),
     navWallets: (page: Page): Locator => page.getByRole('link', { name: label('wallets.wallets') }),
     navTags: (page: Page): Locator => page.getByRole('link', { name: label('tags.tags') }),

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,17 +6,34 @@ set -e
 # The new Vite app reads config from `window.__APP_CONFIG__` (declared in index.html
 # with `__VITE_*__` placeholders). Here we replace those placeholders with the
 # container's env vars so a single built image serves every environment without a
-# rebuild. Fail fast if a required var is missing — otherwise the SPA would resolve
-# config to `undefined` and redirect-loop to /undefined.
+# rebuild. VITE_WEBSITE_URL and VITE_GATEWAY_URL fail fast if missing — otherwise the
+# SPA would resolve config to `undefined` and redirect-loop to /undefined. The release
+# metadata vars (VITE_APP_VERSION, VITE_APP_COMMIT) are display-only, so they default
+# to an empty string instead — local/ad-hoc containers won't have them set, and the
+# footer degrades gracefully when they're absent.
 
 : "${VITE_WEBSITE_URL:?VITE_WEBSITE_URL must be set}"
 : "${VITE_GATEWAY_URL:?VITE_GATEWAY_URL must be set}"
+: "${VITE_APP_VERSION:=}"
+: "${VITE_APP_COMMIT:=}"
+
+# VITE_APP_VERSION/VITE_APP_COMMIT come from a git tag or branch name (a snapshot build
+# passes the branch name as the tag, e.g. via workflow_dispatch), unlike the operator-set
+# static URLs above — a branch name may legally contain sed metacharacters (`&`, `|`, `\`).
+# Escape them before they reach the replacement text below, otherwise `&` re-inserts the
+# unreplaced placeholder, `|` collides with the `s|...|...|` delimiter (sed exits non-zero,
+# which aborts this script under `set -e` before nginx starts), and `\` can be read as an
+# escape sequence.
+ESCAPED_VITE_APP_VERSION=$(printf '%s' "$VITE_APP_VERSION" | sed -e 's/[&|\\]/\\&/g')
+ESCAPED_VITE_APP_COMMIT=$(printf '%s' "$VITE_APP_COMMIT" | sed -e 's/[&|\\]/\\&/g')
 
 INDEX_HTML=/usr/share/nginx/html/index.html
 
 sed -i \
     -e "s|__VITE_WEBSITE_URL__|${VITE_WEBSITE_URL}|g" \
     -e "s|__VITE_GATEWAY_URL__|${VITE_GATEWAY_URL}|g" \
+    -e "s|__VITE_APP_VERSION__|${ESCAPED_VITE_APP_VERSION}|g" \
+    -e "s|__VITE_APP_COMMIT__|${ESCAPED_VITE_APP_COMMIT}|g" \
     "$INDEX_HTML"
 
 exec "$@"

--- a/env.d.ts
+++ b/env.d.ts
@@ -9,6 +9,8 @@ interface ViteTypeOptions {
 interface ImportMetaEnv {
     readonly VITE_WEBSITE_URL: string
     readonly VITE_GATEWAY_URL: string
+    readonly VITE_APP_VERSION: string
+    readonly VITE_APP_COMMIT: string
 }
 
 interface ImportMeta {

--- a/index.html
+++ b/index.html
@@ -13,6 +13,8 @@
       window.__APP_CONFIG__ = {
         VITE_WEBSITE_URL: '__VITE_WEBSITE_URL__',
         VITE_GATEWAY_URL: '__VITE_GATEWAY_URL__',
+        VITE_APP_VERSION: '__VITE_APP_VERSION__',
+        VITE_APP_COMMIT: '__VITE_APP_COMMIT__',
       }
     </script>
 

--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -1,10 +1,31 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { webSiteLink } from '@/shared/links'
+import { getEnv } from '@/shared/env'
+import { webSiteLink, releaseTagLink, commitLink } from '@/shared/links'
 
 const { t } = useI18n()
 
 const year = new Date().getFullYear()
+
+// Snapshot builds from master pass the branch name as the VITE_APP_VERSION build-arg,
+// so only treat it as a release tag when it looks like one (e.g. "v2.0.5").
+const releaseTagPattern = /^v\d/
+
+const version = computed(() => getEnv('VITE_APP_VERSION'))
+const commit = computed(() => getEnv('VITE_APP_COMMIT'))
+
+const hasReleaseTag = computed(() => releaseTagPattern.test(version.value))
+const hasCommit = computed(() => commit.value.length > 0)
+
+const shortCommit = computed(() => commit.value.slice(0, 7))
+
+const versionHref = computed(() => releaseTagLink(version.value))
+// With a release tag, both the tag and the sha link to the same release page;
+// without one, the sha links to its own commit page.
+const commitHref = computed(() =>
+    hasReleaseTag.value ? releaseTagLink(version.value) : commitLink(commit.value),
+)
 </script>
 
 <template>
@@ -13,6 +34,24 @@ const year = new Date().getFullYear()
             <div class="grid grid-cols-1 sm:grid-cols-3 items-center gap-2">
                 <div class="text-center sm:text-left">
                     © {{ year }} Cash Track
+                    <template v-if="hasReleaseTag">
+                        ·
+                        <ULink
+                            :href="versionHref"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="text-primary-500 hover:text-primary-700 transition-colors"
+                        >{{ version }}</ULink>
+                    </template>
+                    <template v-if="hasCommit">
+                        ·
+                        <ULink
+                            :href="commitHref"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="text-primary-500 hover:text-primary-700 transition-colors"
+                        >{{ shortCommit }}</ULink>
+                    </template>
                 </div>
                 <div class="text-center" v-html="t('madeBy')" />
                 <div class="text-center sm:text-right">

--- a/src/components/__tests__/AppFooter.spec.ts
+++ b/src/components/__tests__/AppFooter.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import AppFooter from '../AppFooter.vue'
 
@@ -8,7 +8,13 @@ vi.mock('vue-i18n', () => ({
 
 vi.mock('@/shared/links', () => ({
     webSiteLink: (path: string) => `https://cash-track.app${path}`,
+    releaseTagLink: (tag: string) => `https://github.com/cash-track/frontend/releases/tag/${tag}`,
+    commitLink: (sha: string) => `https://github.com/cash-track/frontend/commit/${sha}`,
 }))
+
+afterEach(() => {
+    delete window.__APP_CONFIG__
+})
 
 describe('AppFooter', () => {
     it('renders exactly 3 elements with class text-primary-500', () => {
@@ -35,5 +41,69 @@ describe('AppFooter', () => {
         const wrapper = mount(AppFooter)
         expect(wrapper.text()).toContain('Cash Track')
         expect(wrapper.text()).toContain(String(new Date().getFullYear()))
+    })
+
+    describe('release version / commit sha', () => {
+        const fullSha = '5009cb0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        const shortSha = '5009cb0'
+
+        it('renders tag and shortened sha, both linked to the release page, when both are set', () => {
+            window.__APP_CONFIG__ = {
+                VITE_APP_VERSION: 'v2.0.5',
+                VITE_APP_COMMIT: fullSha,
+            }
+            const wrapper = mount(AppFooter)
+
+            expect(wrapper.text()).toContain('· v2.0.5 · ' + shortSha)
+            expect(wrapper.text()).not.toContain(fullSha)
+
+            const releaseUrl = 'https://github.com/cash-track/frontend/releases/tag/v2.0.5'
+            const tagLink = wrapper.findAll('a').find(a => a.text() === 'v2.0.5')
+            const shaLink = wrapper.findAll('a').find(a => a.text() === shortSha)
+            expect(tagLink?.attributes('href')).toBe(releaseUrl)
+            expect(shaLink?.attributes('href')).toBe(releaseUrl)
+            expect(tagLink?.attributes('target')).toBe('_blank')
+            expect(tagLink?.attributes('rel')).toBe('noopener noreferrer')
+            expect(shaLink?.attributes('target')).toBe('_blank')
+            expect(shaLink?.attributes('rel')).toBe('noopener noreferrer')
+        })
+
+        it('renders only the shortened sha, linked to the commit page, when the tag is not a release tag', () => {
+            // Snapshot builds pass the branch name (e.g. "master") as the version build-arg.
+            window.__APP_CONFIG__ = {
+                VITE_APP_VERSION: 'master',
+                VITE_APP_COMMIT: fullSha,
+            }
+            const wrapper = mount(AppFooter)
+
+            expect(wrapper.text()).toContain('· ' + shortSha)
+            expect(wrapper.text()).not.toContain('master')
+
+            const shaLink = wrapper.findAll('a').find(a => a.text() === shortSha)
+            expect(shaLink?.attributes('href')).toBe(
+                `https://github.com/cash-track/frontend/commit/${fullSha}`,
+            )
+        })
+
+        it('renders only the shortened sha, linked to the commit page, when the tag is absent', () => {
+            window.__APP_CONFIG__ = {
+                VITE_APP_COMMIT: fullSha,
+            }
+            const wrapper = mount(AppFooter)
+
+            expect(wrapper.text()).toContain('· ' + shortSha)
+
+            const shaLink = wrapper.findAll('a').find(a => a.text() === shortSha)
+            expect(shaLink?.attributes('href')).toBe(
+                `https://github.com/cash-track/frontend/commit/${fullSha}`,
+            )
+        })
+
+        it('renders the plain copyright line with no separator or links when neither is set', () => {
+            const wrapper = mount(AppFooter)
+
+            expect(wrapper.text()).not.toContain('·')
+            expect(wrapper.findAll('.text-primary-500')).toHaveLength(3)
+        })
     })
 })

--- a/src/shared/links.ts
+++ b/src/shared/links.ts
@@ -7,3 +7,11 @@ export function webSiteLink(path: string): string {
 export function gatewayLink(path: string): string {
     return getEnv('VITE_GATEWAY_URL') + path
 }
+
+export function releaseTagLink(tag: string): string {
+    return `https://github.com/cash-track/frontend/releases/tag/${tag}`
+}
+
+export function commitLink(sha: string): string {
+    return `https://github.com/cash-track/frontend/commit/${sha}`
+}


### PR DESCRIPTION
## Problem

There is no way to tell which revision of the SPA is actually being served — after a deploy, a cached build is indistinguishable from the new one. Closes #124.

## Changes

- The footer copyright line now shows the deployed revision: `© 2026 Cash Track · v2.0.5 · 5009cb0`, with middle-dot dividers. The tag and the 7-char sha each link to the GitHub release page (`target="_blank" rel="noopener noreferrer"`, styled like the existing footer links).
- Graceful degradation: with no values (local `vite dev`, preview, unit tests) the plain `© 2026 Cash Track` renders with no dangling separators; snapshot builds whose tag build-arg is a branch name (not matching `^v\d`) show the sha only, linked to the commit page instead.
- Plumbing reuses the runtime-config mechanism end to end: the shared CI build workflow already passes `GIT_TAG`/`GIT_COMMIT` build args, so the Dockerfile consumes them as production-stage `ENV` only (nothing is baked into the Vite build), `entrypoint.sh` injects them into `window.__APP_CONFIG__` at container start (default-empty for these two vars — the URL vars keep their fail-fast — and with `&`/`|`/`\` escaped so branch names can't corrupt the substitution or abort startup), and the app reads them via `getEnv('VITE_APP_VERSION')` / `getEnv('VITE_APP_COMMIT')`. New vars declared in `env.d.ts` and `index.html`. No CI changes required.
- `make build` passes the same build args for local parity (`RELEASE_VERSION` + `git rev-parse HEAD`).
- New `releaseTagLink()` / `commitLink()` helpers in `src/shared/links.ts`.

## Verification

- Two independent review rounds; round 1 findings (sed metacharacter escaping in `entrypoint.sh`, an `aria-label` that masked the version text from screen readers) fixed and re-verified — round 2 confirmed the escaping against BusyBox sed inside the actual `nginx:stable-alpine` base image with adversarial inputs and returned no material findings.
- Unit: 669/669 Vitest tests pass, including 8 `AppFooter.spec.ts` cases covering all four footer states with href/target/rel assertions. `type-check` and `lint` clean.
- E2E: `navigation.spec.ts` 11/11 including the new NAV-11 case (graceful fallback on the dev stack); mobile-chrome project 9/9.
- Full-chain Docker proof: image built with `GIT_TAG=v9.9.9` renders `© 2026 Cash Track · v9.9.9 · 0123456` with both links to the release page; rebuilt with `GIT_TAG=master` renders the sha only, linked to the commit page. Injected `window.__APP_CONFIG__` verified via curl with zero leftover placeholders.
- Live dev stack: footer fallback verified in the browser on `/wallets` and `/profile`.