### PR TITLE
fix(frontend): prompt users to reload when a new version is deployed

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -10,6 +10,7 @@ import AppHeader from '@/components/AppHeader.vue'
 import AppFooter from '@/components/AppFooter.vue'
 import EmailIsNotConfirmedAlert from '@/components/profile/EmailIsNotConfirmedAlert.vue'
 import LoadErrorAlert from '@/components/Shared/LoadErrorAlert.vue'
+import AppUpdatePrompt from '@/components/Shared/AppUpdatePrompt.vue'
 import { useProfileStore } from '@/stores/profile'
 import { useAuthStore } from '@/stores/auth'
 import { useLocaleStore, syncLocaleWithI18n } from '@/stores/locale'
@@ -67,6 +68,8 @@ watch(locale, () => setDocumentTitle(router.currentRoute.value))
             </UContainer>
 
             <AppFooter />
+
+            <AppUpdatePrompt />
         </div>
     </UApp>
 </template>

--- a/src/__tests__/App.spec.ts
+++ b/src/__tests__/App.spec.ts
@@ -91,6 +91,7 @@ const stubs = {
     AppFooter: { template: '<div />' },
     EmailIsNotConfirmedAlert: { template: '<div class="email-alert-stub" />' },
     LoadErrorAlert: loadErrorAlertStub,
+    AppUpdatePrompt: { template: '<div />' },
 }
 
 // -- import App after all mocks are set up ------------------------------------

--- a/src/__tests__/pwa.spec.ts
+++ b/src/__tests__/pwa.spec.ts
@@ -1,14 +1,255 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { RegisterSWOptions } from 'virtual:pwa-register'
 
 // Shim the virtual module so vitest can resolve it outside the vite-plugin-pwa build pipeline.
-vi.mock('virtual:pwa-register', () => ({ registerSW: vi.fn() }))
+const { mockUpdateSW, mockRegisterSW } = vi.hoisted(() => {
+    const mockUpdateSW = vi.fn(async (_reloadPage?: boolean) => {})
+    const mockRegisterSW = vi.fn((_options?: unknown) => mockUpdateSW)
+    return { mockUpdateSW, mockRegisterSW }
+})
+vi.mock('virtual:pwa-register', () => ({ registerSW: mockRegisterSW }))
 
-import { registerSW } from 'virtual:pwa-register'
-import { setupPWA } from '../pwa'
+function makeRegistration(update: () => Promise<void>) {
+    return { update: vi.fn(update) } as unknown as ServiceWorkerRegistration
+}
 
-describe('setupPWA', () => {
-    it('calls registerSW with { immediate: true }', () => {
+async function loadPwa() {
+    vi.resetModules()
+    return import('../pwa')
+}
+
+function registeredOptions(): RegisterSWOptions {
+    const call = mockRegisterSW.mock.calls.at(-1)
+    return call![0] as RegisterSWOptions
+}
+
+describe('pwa', () => {
+    beforeEach(() => {
+        mockRegisterSW.mockClear()
+        mockUpdateSW.mockClear()
+        sessionStorage.clear()
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+        vi.restoreAllMocks()
+    })
+
+    it('setupPWA() registers the service worker with immediate:true and all handlers wired', async () => {
+        const { setupPWA } = await loadPwa()
         setupPWA()
-        expect(registerSW).toHaveBeenCalledExactlyOnceWith({ immediate: true })
+
+        expect(mockRegisterSW).toHaveBeenCalledTimes(1)
+        const options = registeredOptions()
+        expect(options.immediate).toBe(true)
+        expect(typeof options.onNeedRefresh).toBe('function')
+        expect(typeof options.onRegisteredSW).toBe('function')
+        expect(typeof options.onRegisterError).toBe('function')
+    })
+
+    it('onNeedRefresh flips needRefresh to true', async () => {
+        const pwa = await loadPwa()
+        pwa.setupPWA()
+        const { needRefresh } = pwa.usePWAUpdate()
+
+        expect(needRefresh.value).toBe(false)
+        registeredOptions().onNeedRefresh!()
+        expect(needRefresh.value).toBe(true)
+    })
+
+    it('updateApp() invokes the updateSW function returned by registerSW', async () => {
+        const pwa = await loadPwa()
+        pwa.setupPWA()
+
+        await pwa.updateApp()
+
+        expect(mockUpdateSW).toHaveBeenCalledExactlyOnceWith(true)
+    })
+
+    it('updateApp() is a no-op when called before setupPWA()', async () => {
+        const pwa = await loadPwa()
+
+        await expect(pwa.updateApp()).resolves.toBeUndefined()
+        expect(mockUpdateSW).not.toHaveBeenCalled()
+    })
+
+    it('onRegisterError swallows the error without throwing', async () => {
+        const pwa = await loadPwa()
+        pwa.setupPWA()
+
+        expect(() => registeredOptions().onRegisterError!(new Error('registration failed'))).not.toThrow()
+    })
+
+    describe('onRegisteredSW', () => {
+        it('does nothing when registration is undefined', async () => {
+            const pwa = await loadPwa()
+            pwa.setupPWA()
+
+            expect(() => registeredOptions().onRegisteredSW!('sw.js', undefined)).not.toThrow()
+        })
+
+        it('polls registration.update() every 60 minutes', async () => {
+            vi.useFakeTimers()
+            const pwa = await loadPwa()
+            pwa.setupPWA()
+
+            const registration = makeRegistration(async () => {})
+            registeredOptions().onRegisteredSW!('sw.js', registration)
+
+            expect(registration.update).not.toHaveBeenCalled()
+
+            await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
+            expect(registration.update).toHaveBeenCalledTimes(1)
+
+            await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
+            expect(registration.update).toHaveBeenCalledTimes(2)
+        })
+
+        it('swallows registration.update() rejections from the interval check', async () => {
+            vi.useFakeTimers()
+            const pwa = await loadPwa()
+            pwa.setupPWA()
+
+            const registration = makeRegistration(async () => {
+                throw new Error('offline')
+            })
+            registeredOptions().onRegisteredSW!('sw.js', registration)
+
+            // If the rejection weren't swallowed in source, this would surface
+            // as an unhandled rejection and fail the test.
+            await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
+            expect(registration.update).toHaveBeenCalledTimes(1)
+        })
+
+        it('calls registration.update() when the document becomes visible', async () => {
+            const pwa = await loadPwa()
+            pwa.setupPWA()
+
+            const registration = makeRegistration(async () => {})
+            registeredOptions().onRegisteredSW!('sw.js', registration)
+
+            Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true })
+            document.dispatchEvent(new Event('visibilitychange'))
+
+            expect(registration.update).toHaveBeenCalledTimes(1)
+        })
+
+        it('does not call registration.update() while the document is hidden', async () => {
+            const pwa = await loadPwa()
+            pwa.setupPWA()
+
+            const registration = makeRegistration(async () => {})
+            registeredOptions().onRegisteredSW!('sw.js', registration)
+
+            Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true })
+            document.dispatchEvent(new Event('visibilitychange'))
+
+            expect(registration.update).not.toHaveBeenCalled()
+        })
+
+        it('swallows registration.update() rejections from the visibilitychange check', async () => {
+            const pwa = await loadPwa()
+            pwa.setupPWA()
+
+            const registration = makeRegistration(async () => {
+                throw new Error('offline')
+            })
+            registeredOptions().onRegisteredSW!('sw.js', registration)
+
+            Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true })
+            expect(() => document.dispatchEvent(new Event('visibilitychange'))).not.toThrow()
+        })
+    })
+
+    describe('vite:preloadError handling', () => {
+        // jsdom's Location#reload is non-configurable/non-writable, so it can't be
+        // spied on directly (vi.spyOn throws "Cannot redefine property: reload").
+        // window's own `location` property IS configurable, so swap the whole
+        // object out for the duration of the test and restore it afterwards.
+        const originalLocation = window.location
+
+        function mockLocationReload() {
+            const reloadSpy = vi.fn()
+            Object.defineProperty(window, 'location', {
+                value: { reload: reloadSpy },
+                writable: true,
+                configurable: true,
+            })
+            return reloadSpy
+        }
+
+        afterEach(() => {
+            Object.defineProperty(window, 'location', {
+                value: originalLocation,
+                writable: true,
+                configurable: true,
+            })
+        })
+
+        it('reloads the page once and stores the reload timestamp', async () => {
+            vi.useFakeTimers()
+            vi.setSystemTime(1_700_000_000_000)
+            const reloadSpy = mockLocationReload()
+            const pwa = await loadPwa()
+            pwa.setupPWA()
+
+            window.dispatchEvent(new Event('vite:preloadError'))
+
+            expect(reloadSpy).toHaveBeenCalledTimes(1)
+            expect(sessionStorage.getItem('ct:preloadErrorReloadedAt')).toBe('1700000000000')
+        })
+
+        it('does not reload a second time for a second preload error in the same load', async () => {
+            const reloadSpy = mockLocationReload()
+            const pwa = await loadPwa()
+            pwa.setupPWA()
+
+            window.dispatchEvent(new Event('vite:preloadError'))
+            window.dispatchEvent(new Event('vite:preloadError'))
+
+            expect(reloadSpy).toHaveBeenCalledTimes(1)
+        })
+
+        // This is the scenario the guard exists for: a reload doesn't clear
+        // sessionStorage (it survives navigation in the same tab), so a second,
+        // independent page load that hits vite:preloadError again shortly after
+        // must not retrigger a reload — otherwise a persistent failure (a chunk
+        // missing from the CDN, a flaky network) loops forever.
+        it('does not reload again on the next page load within the cooldown window', async () => {
+            vi.useFakeTimers()
+            const reloadSpy = mockLocationReload()
+
+            // Load 1: a preload error triggers the guarded reload.
+            const load1 = await loadPwa()
+            load1.setupPWA()
+            window.dispatchEvent(new Event('vite:preloadError'))
+            expect(reloadSpy).toHaveBeenCalledTimes(1)
+
+            // Load 2 (simulated page reload): fresh module state, but
+            // sessionStorage — and therefore the cooldown — survives.
+            const load2 = await loadPwa()
+            load2.setupPWA()
+            window.dispatchEvent(new Event('vite:preloadError'))
+
+            expect(reloadSpy).toHaveBeenCalledTimes(1)
+        })
+
+        it('reloads again on a later page load once the cooldown window has elapsed', async () => {
+            vi.useFakeTimers()
+            const reloadSpy = mockLocationReload()
+
+            const load1 = await loadPwa()
+            load1.setupPWA()
+            window.dispatchEvent(new Event('vite:preloadError'))
+            expect(reloadSpy).toHaveBeenCalledTimes(1)
+
+            await vi.advanceTimersByTimeAsync(60 * 1000 + 1)
+
+            const load2 = await loadPwa()
+            load2.setupPWA()
+            window.dispatchEvent(new Event('vite:preloadError'))
+
+            expect(reloadSpy).toHaveBeenCalledTimes(2)
+        })
     })
 })

--- a/src/components/Shared/AppUpdatePrompt.vue
+++ b/src/components/Shared/AppUpdatePrompt.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { usePWAUpdate } from '@/pwa'
+
+const { t } = useI18n()
+const { needRefresh, updateApp } = usePWAUpdate()
+
+const reloading = ref(false)
+
+async function onReload() {
+    reloading.value = true
+    await updateApp()
+}
+</script>
+
+<template>
+    <div
+        v-if="needRefresh"
+        class="fixed inset-x-0 bottom-0 z-40 flex justify-center px-4 pb-[max(env(safe-area-inset-bottom),1rem)]"
+    >
+        <div
+            class="flex w-full max-w-md items-center justify-between gap-3 rounded-lg border border-default bg-elevated px-4 py-3 shadow-lg"
+        >
+            <p class="text-sm text-default">{{ t('pwa.newVersion') }}</p>
+            <UButton
+                :label="t('pwa.reload')"
+                color="primary"
+                size="sm"
+                :loading="reloading"
+                :disabled="reloading"
+                @click="onReload"
+            />
+        </div>
+    </div>
+</template>

--- a/src/components/Shared/__tests__/AppUpdatePrompt.spec.ts
+++ b/src/components/Shared/__tests__/AppUpdatePrompt.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AppUpdatePrompt from '../AppUpdatePrompt.vue'
+
+vi.mock('vue-i18n', () => ({
+    useI18n: () => ({ t: (key: string) => key }),
+}))
+
+// vi.hoisted() runs before static imports are initialized, so a real Vue `ref()`
+// (which needs the statically-imported `ref` binding) can't be built here directly —
+// referencing it throws a TDZ ReferenceError. Use a plain state carrier instead and
+// construct the real ref lazily inside the (async) mock factory below, which runs
+// after imports have settled.
+const { mockNeedRefreshState, mockUpdateApp } = vi.hoisted(() => ({
+    mockNeedRefreshState: { value: false },
+    mockUpdateApp: vi.fn(async () => {}),
+}))
+
+vi.mock('@/pwa', async () => {
+    const { ref } = await import('vue')
+    return {
+        usePWAUpdate: () => ({
+            needRefresh: ref(mockNeedRefreshState.value),
+            updateApp: mockUpdateApp,
+        }),
+    }
+})
+
+// Module-level stub so findAllComponents(uButtonStub) resolves by reference.
+const uButtonStub = {
+    template: '<button :disabled="disabled" @click="$emit(\'click\')">{{ label }}</button>',
+    props: ['label', 'color', 'size', 'loading', 'disabled'],
+    emits: ['click'],
+}
+
+const makeGlobal = () => ({
+    global: {
+        stubs: {
+            UButton: uButtonStub,
+            Button: uButtonStub,
+        },
+    },
+})
+
+describe('AppUpdatePrompt', () => {
+    beforeEach(() => {
+        mockNeedRefreshState.value = false
+        mockUpdateApp.mockClear()
+    })
+
+    it('renders nothing when needRefresh is false', () => {
+        const wrapper = mount(AppUpdatePrompt, makeGlobal())
+        expect(wrapper.find('div').exists()).toBe(false)
+    })
+
+    it('renders the update message and reload button when needRefresh is true', () => {
+        mockNeedRefreshState.value = true
+        const wrapper = mount(AppUpdatePrompt, makeGlobal())
+        expect(wrapper.text()).toContain('pwa.newVersion')
+        expect(wrapper.text()).toContain('pwa.reload')
+    })
+
+    it('calls updateApp when the reload button is clicked', async () => {
+        mockNeedRefreshState.value = true
+        const wrapper = mount(AppUpdatePrompt, makeGlobal())
+        await wrapper.find('button').trigger('click')
+        expect(mockUpdateApp).toHaveBeenCalledTimes(1)
+    })
+
+    it('disables the reload button after clicking to show a loading state', async () => {
+        mockNeedRefreshState.value = true
+        const wrapper = mount(AppUpdatePrompt, makeGlobal())
+        const button = wrapper.find('button')
+        expect(button.attributes('disabled')).toBeUndefined()
+
+        await button.trigger('click')
+
+        expect(button.attributes('disabled')).toBeDefined()
+    })
+
+    it('does not disable the button before any interaction', () => {
+        mockNeedRefreshState.value = true
+        const wrapper = mount(AppUpdatePrompt, makeGlobal())
+        const button = wrapper.findComponent(uButtonStub)
+        expect(button.props('disabled')).toBe(false)
+        expect(button.props('loading')).toBe(false)
+    })
+})

--- a/src/lang/messages/en.ts
+++ b/src/lang/messages/en.ts
@@ -331,4 +331,9 @@ export default {
         tagNamed: '{name}',
         tags: 'Tags',
     },
+
+    pwa: {
+        newVersion: 'A new version is available',
+        reload: 'Reload',
+    },
 };

--- a/src/lang/messages/uk.ts
+++ b/src/lang/messages/uk.ts
@@ -331,4 +331,9 @@ export default {
         tagNamed: '{name}',
         tags: 'Теги',
     },
+
+    pwa: {
+        newVersion: 'Доступна нова версія',
+        reload: 'Оновити',
+    },
 };

--- a/src/pwa.ts
+++ b/src/pwa.ts
@@ -1,5 +1,74 @@
+import { ref } from 'vue'
 import { registerSW } from 'virtual:pwa-register'
 
+// How often to poll for a new service worker while the tab stays open.
+const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000
+
+// Guards against a vite:preloadError reload loop (e.g. a stale tab that keeps
+// hitting a deleted hashed chunk). sessionStorage holds the timestamp of the
+// last such reload, which survives the reload itself (same tab) — so a second
+// preload error on the very next load only reloads again once the cooldown has
+// elapsed. That way a genuine one-off staleness case still recovers immediately
+// (no prior timestamp), while a persistent failure (chunk missing from the CDN,
+// flaky network) can't retrigger a reload on every single load.
+const PRELOAD_ERROR_RELOAD_KEY = 'ct:preloadErrorReloadedAt'
+const PRELOAD_ERROR_RELOAD_COOLDOWN_MS = 60 * 1000
+
+// Reactive flag flipped by onNeedRefresh once a new service worker is waiting.
+const needRefresh = ref(false)
+
+// Set by setupPWA(); calling it posts SKIP_WAITING to the waiting worker. The
+// page reload itself is handled by the pwa client once the new worker takes
+// control (see workbox-window's "controlling" listener) — we never reload here.
+let updateSWFn: ((reloadPage?: boolean) => Promise<void>) | undefined
+
+export function usePWAUpdate() {
+    return { needRefresh, updateApp }
+}
+
+export async function updateApp() {
+    if (!updateSWFn) {
+        return
+    }
+    await updateSWFn(true)
+}
+
+function onNeedRefresh() {
+    needRefresh.value = true
+}
+
+function checkForUpdate(registration: ServiceWorkerRegistration) {
+    registration.update().catch(() => {})
+}
+
+function onRegisteredSW(_swScriptUrl: string, registration: ServiceWorkerRegistration | undefined) {
+    if (!registration) {
+        return
+    }
+
+    setInterval(() => checkForUpdate(registration), UPDATE_CHECK_INTERVAL_MS)
+
+    document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') {
+            checkForUpdate(registration)
+        }
+    })
+}
+
+function onRegisterError() {
+    // A failed service worker registration must never break the app.
+}
+
+function onPreloadError() {
+    const lastReloadAt = Number(sessionStorage.getItem(PRELOAD_ERROR_RELOAD_KEY) ?? 0)
+    if (Date.now() - lastReloadAt < PRELOAD_ERROR_RELOAD_COOLDOWN_MS) {
+        return
+    }
+    sessionStorage.setItem(PRELOAD_ERROR_RELOAD_KEY, String(Date.now()))
+    window.location.reload()
+}
+
 export function setupPWA() {
-    registerSW({ immediate: true })
+    updateSWFn = registerSW({ immediate: true, onNeedRefresh, onRegisteredSW, onRegisterError })
+    window.addEventListener('vite:preloadError', onPreloadError)
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,12 @@ export default defineConfig({
         // The API is a different origin (gateway) so it is never precached;
         // navigateFallbackDenylist keeps any /api path off the SPA fallback.
         VitePWA({
-            registerType: 'autoUpdate',
+            // Prompt mode: a new service worker installs and waits; src/pwa.ts
+            // surfaces needRefresh so the UI can ask the user before activating
+            // it (updateApp() posts SKIP_WAITING). autoUpdate would activate
+            // silently, but with injectRegister: false its unconditional
+            // self.skipWaiting() is never wired in, so updates never applied.
+            registerType: 'prompt',
             injectRegister: false,        // we register manually (see src/pwa.ts)
             manifest: false,              // keep the static public/site.webmanifest
             workbox: {


### PR DESCRIPTION
## Problem statement

Closes #106.

After a new image is deployed, users keep running the previous version of the SPA indefinitely — reloading does not help; only closing every tab/PWA window picks up the release.

Root cause (verified by diffing the `2.0.5`/`2.0.6` images and the shipped bundles): `registerType: 'autoUpdate'` combined with `injectRegister: false` disables vite-plugin-pwa's autoUpdate defaults, so the generated `sw.js` never calls `self.skipWaiting()` unconditionally, and the auto-mode client never posts the `SKIP_WAITING` message. A newly installed service worker therefore stays in the *waiting* state forever while the old worker keeps serving the old precached `index.html` and assets. The app also never re-checked for a new service worker during a session, so long-lived tabs and installed PWAs didn't even discover deploys.

## Changes

- `vite.config.ts`: `registerType: 'prompt'` — the service worker now activates only when the user opts in.
- `src/pwa.ts`: reworked into `setupPWA()` + `usePWAUpdate()` exposing a reactive `needRefresh` and `updateApp()`, which applies the waiting service worker (`SKIP_WAITING` → `controlling` → reload). Registration schedules `registration.update()` hourly and on tab visibility, with all rejections swallowed (an update check must never surface an error).
- `src/components/Shared/AppUpdatePrompt.vue` (rendered from `App.vue`): persistent bottom banner — “A new version is available” with a **Reload** action; i18n keys added to both `en` and `uk` locales; button shows a disabled/loading state while the new worker takes over.
- `vite:preloadError` safety net: if a stale open tab requests a hashed chunk that no longer exists after a deploy, the page reloads once (60-second `sessionStorage` cooldown prevents reload loops on persistent failures).

Note for operators: full effect also requires the Cloudflare zone change documented in cash-track/infra (a cache rule bypassing `/sw.js`), since the edge currently caches `sw.js` for 4h and delays update discovery.

## Verification

- Independent code review: one finding (the preload-error reload guard was cleared on startup, defeating cross-load loop protection) — fixed with the cooldown-timestamp approach; re-review returned no material findings.
- `npm run test:unit -- --run`: 688/688 green, including 15 new pwa specs (needRefresh flow, hourly/visibility update checks, rejection swallowing, cross-page-load cooldown scenarios) and 5 banner specs.
- `npm run type-check`, `npm run lint`, `npm run build`: clean; generated `dist/sw.js` confirmed to contain `skipWaiting()` only inside the `SKIP_WAITING` message listener.
- Real-browser end-to-end proof against `npm run preview`: install build A → deploy build B → reload → banner appears (no forced reload in prompt mode) → click **Reload** → new service worker active with `waiting: false` and build B's bundle hash served.