### PR TITLE
fix(frontend): security dependency upgrades (3 advisories)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2396,9 +2396,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2470,9 +2470,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6504,9 +6504,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7870,9 +7870,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15333,16 +15333,16 @@
       }
     },
     "node_modules/workbox-build/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/workbox-build/node_modules/fs-extra": {


### PR DESCRIPTION
## Security dependency upgrades — `frontend`

Source of findings: **Dependabot**

| Severity | Package | From → To | CVE / GHSA |
|---|---|---|---|
| High | `brace-expansion` (root) | 2.1.1 → 2.1.2 | CVE-2026-13149 / [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) |
| High | `brace-expansion` (eslint, @eslint/eslintrc, @eslint/config-array) | 1.1.15 → 1.1.16 | CVE-2026-13149 / [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) |
| High | `brace-expansion` (workbox-build) | 5.0.6 → 5.0.8 | CVE-2026-13149 / [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) |

### What changed
- `npm audit fix` (**without** `--force`) moved each of the five transitive `brace-expansion` copies onto its patched maintenance release. All are `dev` scope — they come from `eslint` and `workbox-build`, none ship in the app bundle.
- `package-lock.json` is the only file in the diff; no `package.json` constraints or `overrides` were added.

### Codebase changes
None — lockfile only.

### Verification
- `npm run test:unit -- --run` → **82 test files passed (82), 688 tests passed (688)**.
- `npm run lint` → **0 errors** (52 pre-existing `playwright/*` warnings in `e2e/`, unrelated and unchanged).
- Re-ran `npm audit` → `GHSA-3jxr-9vmj-r5cp` cleared on all three vulnerable ranges.

### Deferred / no fix available
- **`brace-expansion` — [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg)** (high, "DoS via unbounded expansion length causing an OOM crash", published 2026-07-24). Its vulnerable range is `<= 5.0.7` and its **only** patched release is `5.0.8` — upstream shipped no backport to the `1.x` / `2.x` maintenance lines, so the copies under `eslint` (1.1.16) and the root (2.1.2) stay flagged even though both are fully patched for the other advisory.

  Forcing them forward was tried and **does not work**. Adding `overrides: { "brace-expansion": "^5.0.8" }` dedupes the tree to a single 5.0.8 and takes `npm audit` to `found 0 vulnerabilities`, but breaks lint outright:

  ```
  ESLint: 9.39.3
  TypeError: expand is not a function
      at Minimatch.braceExpand (node_modules/@eslint/config-array/node_modules/minimatch/minimatch.js:271:10)
  ```

  `minimatch@3.x` (which `eslint` still bundles) does `module.exports = expand`, whereas brace-expansion 5.x exports a named `{ expand }` under CJS. The override was reverted. npm's own `--force` remedy is to install `eslint@4.0.0`, which is a non-starter.

  Real-world exposure is low: dev-only tooling, expanding the repo's own lint globs, no attacker-controlled input. Recommend waiting for a `1.x`/`2.x` backport or for eslint to drop `minimatch@3`.
