### PR TITLE
fix(charges): keep title autocomplete open while it reloads

### DIFF
--- a/e2e/charges-create.spec.ts
+++ b/e2e/charges-create.spec.ts
@@ -427,4 +427,67 @@ test.describe('S8 — Charge Create', () => {
         }
     })
 
+    // CC-12 — Selecting a partial title suggestion keeps the dropdown open
+    // while it reloads inline, and it auto-hides only once a reload settles on
+    // a single exact match with no tag suggestions left (issue #109).
+    test('CC-12 selecting a partial title suggestion keeps the dropdown open and reloads inline', async ({ request, page }) => {
+        const w = await createWalletViaApi(request, { name: `E2E CC12 ${Date.now()}` })
+        const ts = Date.now()
+        // titleShopping contains titleShop, so both survive the reload.
+        const titleShop = `E2E109Shop${ts}`
+        const titleShopping = `E2E109Shop${ts}ping`
+        // Shorter than titleShop, so clicking that option really changes the
+        // typed text and fires the debounced reload (not the early return).
+        const prefixQuery = titleShop.slice(0, -1)
+        // No overlapping titles or tags — resolves to a single exact match.
+        const titleUnique = `E2E109Solo${ts}`
+        try {
+            await createChargeViaApi(request, w.id, { title: titleShop })
+            await createChargeViaApi(request, w.id, { title: titleShopping })
+            await createChargeViaApi(request, w.id, { title: titleUnique })
+
+            await page.goto(`/wallets/${w.id}`)
+            await expect(page.getByRole('heading', { level: 2 })).toBeVisible({ timeout: 10000 })
+
+            await charge.newChargeButton(page).click()
+            await expect(charge.titleInput(page)).toBeVisible({ timeout: 5000 })
+
+            await charge.titleInput(page).fill(prefixQuery)
+
+            const listbox = page.locator('#charge-title-listbox')
+            const shopOption = listbox.getByText(titleShop, { exact: true })
+            const shoppingOption = listbox.getByText(titleShopping, { exact: true })
+            await expect(shopOption).toBeVisible({ timeout: 8000 })
+            await expect(shoppingOption).toBeVisible({ timeout: 8000 })
+
+            // The listbox sits behind v-if, so a close-then-reopen destroys
+            // this node — identity survival is what a retrying toBeVisible()
+            // assertion cannot detect.
+            const listboxHandle = await listbox.elementHandle()
+
+            await shopOption.click()
+            await expect(charge.titleInput(page)).toHaveValue(titleShop)
+            // The reloaded query still matches both titles.
+            await expect(shoppingOption).toBeVisible({ timeout: 5000 })
+            await expect(shopOption).toBeVisible()
+            expect(await listboxHandle!.evaluate(el => el.isConnected)).toBe(true)
+
+            // Clicking it again matches the typed text exactly — the
+            // early-return path, no reload, box stays open.
+            await shopOption.click()
+            await expect(charge.titleInput(page)).toHaveValue(titleShop)
+            await expect(shoppingOption).toBeVisible()
+            await expect(shopOption).toBeVisible()
+            expect(await listboxHandle!.evaluate(el => el.isConnected)).toBe(true)
+
+            // Single exact match, no tag suggestions — auto-hides.
+            await charge.titleInput(page).fill(titleUnique)
+            await expect(listbox).not.toBeVisible({ timeout: 5000 })
+
+            await assertNoErrorLeak(page)
+        } finally {
+            await deleteWalletViaApi(request, w.id)
+        }
+    })
+
 })

--- a/src/components/wallets/charges/ChargeTitleFormInput.vue
+++ b/src/components/wallets/charges/ChargeTitleFormInput.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { getChargeTitles } from '@/api/charges'
 import { getTagSuggestions } from '@/api/tags'
@@ -79,6 +79,18 @@ const hasResults = computed(() =>
     filteredTagSuggestions.value.length > 0 || filteredTitleSuggestions.value.length > 0,
 )
 
+// Hide only with no unselected tag suggestions left and no title options beyond
+// a single exact match — any unselected tag keeps the box open.
+const shouldAutoHide = computed(() =>
+    filteredTagSuggestions.value.length === 0
+    && (filteredTitleSuggestions.value.length === 0
+        || (filteredTitleSuggestions.value.length === 1 && filteredTitleSuggestions.value[0].selected)),
+)
+
+function applyAutoHide() {
+    dropdownOpen.value = !shouldAutoHide.value
+}
+
 function doAutocomplete(value: string) {
     const q = value.trim()
     highlightedIndex.value = -1
@@ -87,7 +99,11 @@ function doAutocomplete(value: string) {
         return
     }
 
-    if (lastQuery.value === q) return
+    if (lastQuery.value === q) {
+        // No refetch, but the suggestion lists may have changed — re-check.
+        applyAutoHide()
+        return
+    }
     lastQuery.value = q
 
     if (debounceHandle.value !== null) {
@@ -106,7 +122,7 @@ function doAutocomplete(value: string) {
                 if (token !== loadToken) return
                 tagSuggestions.value = tags
                 titleSuggestions.value = titles
-                dropdownOpen.value = hasResults.value
+                applyAutoHide()
             })
             .catch(() => {})
             .finally(() => {
@@ -118,12 +134,18 @@ function doAutocomplete(value: string) {
 function onTagSelect(tag: Tag) {
     if (addedTagIds.value.has(tag.id)) return
     emit('tag-selected', tag)
-    doAutocomplete(props.modelValue)
+    // Deferred so `props.tags` has round-tripped and the re-check sees it.
+    nextTick(() => doAutocomplete(props.modelValue))
 }
 
 function onTitleSelect(title: string) {
+    if (localValue.value === title) {
+        // Unchanged ref assignment fires no watcher — re-check explicitly.
+        doAutocomplete(title)
+        return
+    }
+    // The watcher reloads inline; closing here would flicker the box (#109).
     localValue.value = title
-    dropdownOpen.value = false
 }
 
 function onKeyDown(e: KeyboardEvent) {

--- a/src/components/wallets/charges/__tests__/ChargeTitleFormInput.spec.ts
+++ b/src/components/wallets/charges/__tests__/ChargeTitleFormInput.spec.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ref, nextTick } from 'vue'
-import { shallowMount } from '@vue/test-utils'
+import { shallowMount, flushPromises } from '@vue/test-utils'
 import ChargeTitleFormInput from '../ChargeTitleFormInput.vue'
 import { Tag } from '@/api/models/tag'
+import { getChargeTitles } from '@/api/charges'
+import { getTagSuggestions } from '@/api/tags'
 
 vi.mock('vue-i18n', () => ({
     useI18n: () => ({
@@ -19,30 +21,62 @@ vi.mock('@/api/tags', () => ({
     getTagSuggestions: vi.fn().mockResolvedValue([]),
 }))
 
+function makeTagSuggestion(id: number, name: string): Tag {
+    return new Tag({
+        id,
+        name,
+        icon: null,
+        color: '#123456',
+        userId: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+    })
+}
+
 describe('ChargeTitleFormInput', () => {
     beforeEach(() => {
         vi.clearAllMocks()
     })
 
+    const stubs = {
+        // Render attrs on the stub root so we can assert them via html()
+        UInput: {
+            template: '<div class="uinput-stub" v-bind="$attrs"><slot /></div>',
+            inheritAttrs: false,
+            setup(_: unknown, { attrs }: { attrs: Record<string, unknown> }) {
+                return { attrs }
+            },
+        },
+        UIcon: { template: '<span />', props: ['name', 'class'] },
+        TagChip: { template: '<div />', props: ['tag', 'highlighted', 'id'] },
+        UBadge: { template: '<span><slot /></span>', props: ['variant', 'color', 'size'] },
+    }
+
     function mountInput(modelValue = '') {
         return shallowMount(ChargeTitleFormInput, {
             props: { modelValue, tags: [] },
-            global: {
-                stubs: {
-                    // Render attrs on the stub root so we can assert them via html()
-                    UInput: {
-                        template: '<div class="uinput-stub" v-bind="$attrs"><slot /></div>',
-                        inheritAttrs: false,
-                        setup(_, { attrs }) {
-                            return { attrs }
-                        },
-                    },
-                    UIcon: { template: '<span />', props: ['name', 'class'] },
-                    TagChip: { template: '<div />', props: ['tag', 'highlighted', 'id'] },
-                    UBadge: { template: '<span><slot /></span>', props: ['variant', 'color', 'size'] },
+            global: { stubs },
+        })
+    }
+
+    // A synchronous `tag-selected` listener mirroring ChargeCreate/ChargeEdit.
+    // Vue calls emit listeners synchronously, so the `tags` prop update lands
+    // before the component's deferred nextTick() re-check — a bare setProps()
+    // after onTagSelect() returns schedules its flush too late to reproduce it.
+    function mountInputWithParent(modelValue: string, initialTags: Tag[] = []) {
+        let currentTags = initialTags
+        const wrapper = shallowMount(ChargeTitleFormInput, {
+            props: {
+                modelValue,
+                tags: currentTags,
+                onTagSelected: (tag: Tag) => {
+                    currentTags = [tag, ...currentTags]
+                    wrapper.setProps({ tags: currentTags })
                 },
             },
+            global: { stubs },
         })
+        return wrapper
     }
 
     it('UInput stub receives role="combobox"', () => {
@@ -254,6 +288,240 @@ describe('ChargeTitleFormInput', () => {
             await nextTick()
 
             expect(vm.titleSuggestions).toEqual([])
+        })
+    })
+
+    // Selecting a partial suggestion (typed "Sho", clicked "Shop") must not
+    // flicker the dropdown closed-then-open while the reload runs.
+    describe('anti-flicker + auto-hide rule (issue #109)', () => {
+        afterEach(() => {
+            vi.useRealTimers()
+        })
+
+        it('stays open after selecting a partial title suggestion, through the inline reload', async () => {
+            vi.useFakeTimers()
+            vi.mocked(getTagSuggestions).mockResolvedValue([])
+            vi.mocked(getChargeTitles).mockResolvedValue([
+                { title: 'Shop', count: 1 },
+                { title: 'Shopping', count: 2 },
+            ])
+
+            const wrapper = mountInput('Sho')
+            const vm = wrapper.vm as unknown as {
+                dropdownOpen: boolean
+                doAutocomplete: (v: string) => void
+                onTitleSelect: (title: string) => void
+            }
+
+            // Type "Sho" — dropdown opens with both matches.
+            vm.doAutocomplete('Sho')
+            await vi.advanceTimersByTimeAsync(300)
+            expect(vm.dropdownOpen).toBe(true)
+
+            // The box must stay visible for the whole reload.
+            vm.onTitleSelect('Shop')
+            await nextTick()
+            expect(vm.dropdownOpen).toBe(true)
+
+            await vi.advanceTimersByTimeAsync(300)
+            await nextTick()
+            expect(vm.dropdownOpen).toBe(true)
+        })
+
+        it('never emits a false dropdown-open-change between selection and the reload settling', async () => {
+            vi.useFakeTimers()
+            vi.mocked(getTagSuggestions).mockResolvedValue([])
+            vi.mocked(getChargeTitles).mockResolvedValue([
+                { title: 'Shop', count: 1 },
+                { title: 'Shopping', count: 2 },
+            ])
+
+            const wrapper = mountInput('Sho')
+            const vm = wrapper.vm as unknown as {
+                dropdownOpen: boolean
+                doAutocomplete: (v: string) => void
+                onTitleSelect: (title: string) => void
+            }
+
+            vm.doAutocomplete('Sho')
+            await vi.advanceTimersByTimeAsync(300)
+
+            vm.onTitleSelect('Shop')
+            await nextTick()
+            await vi.advanceTimersByTimeAsync(300)
+            await nextTick()
+
+            expect(vm.dropdownOpen).toBe(true)
+            // A single `true` emission for the whole flow (open on the first
+            // load) and never a `false` in between the selection and reload.
+            expect(wrapper.emitted('dropdown-open-change')).toEqual([[true]])
+        })
+
+        it('auto-hides once the reload settles on a single exact title match with no tag suggestions', async () => {
+            vi.useFakeTimers()
+            vi.mocked(getTagSuggestions).mockResolvedValue([])
+            vi.mocked(getChargeTitles).mockResolvedValue([
+                { title: 'Shop', count: 1 },
+                { title: 'Shopping', count: 2 },
+            ])
+
+            const wrapper = mountInput('Sho')
+            const vm = wrapper.vm as unknown as {
+                dropdownOpen: boolean
+                doAutocomplete: (v: string) => void
+                onTitleSelect: (title: string) => void
+            }
+
+            vm.doAutocomplete('Sho')
+            await vi.advanceTimersByTimeAsync(300)
+            expect(vm.dropdownOpen).toBe(true)
+
+            // Selecting "Shop" narrows the reload down to a single exact match.
+            vi.mocked(getChargeTitles).mockResolvedValue([{ title: 'Shop', count: 1 }])
+            vm.onTitleSelect('Shop')
+            await nextTick()
+            // Simulate the parent re-binding v-model after the emit, as the
+            // real ChargeCreate/ChargeEdit forms do.
+            await wrapper.setProps({ modelValue: 'Shop' })
+            await vi.advanceTimersByTimeAsync(300)
+            await nextTick()
+
+            expect(vm.dropdownOpen).toBe(false)
+        })
+
+        it('stays open when an unselected tag suggestion remains, even with a single exact title match', async () => {
+            vi.useFakeTimers()
+            const tagSuggestion = makeTagSuggestion(30, 'shopping')
+            vi.mocked(getTagSuggestions).mockResolvedValue([])
+            vi.mocked(getChargeTitles).mockResolvedValue([
+                { title: 'Shop', count: 1 },
+                { title: 'Shopping', count: 2 },
+            ])
+
+            const wrapper = mountInput('Sho')
+            const vm = wrapper.vm as unknown as {
+                dropdownOpen: boolean
+                doAutocomplete: (v: string) => void
+                onTitleSelect: (title: string) => void
+            }
+
+            vm.doAutocomplete('Sho')
+            await vi.advanceTimersByTimeAsync(300)
+            expect(vm.dropdownOpen).toBe(true)
+
+            // Selecting "Shop" narrows titles to a single exact match, but an
+            // unselected tag suggestion is still present — must stay open.
+            vi.mocked(getTagSuggestions).mockResolvedValue([tagSuggestion])
+            vi.mocked(getChargeTitles).mockResolvedValue([{ title: 'Shop', count: 1 }])
+            vm.onTitleSelect('Shop')
+            await nextTick()
+            await wrapper.setProps({ modelValue: 'Shop' })
+            await vi.advanceTimersByTimeAsync(300)
+            await nextTick()
+
+            expect(vm.dropdownOpen).toBe(true)
+        })
+
+        it('re-evaluates the hide rule on the lastQuery === q early-return path after onTagSelect', async () => {
+            const tagSuggestion = makeTagSuggestion(31, 'shopping')
+
+            const wrapper = mountInputWithParent('Shop')
+            const vm = wrapper.vm as unknown as {
+                dropdownOpen: boolean
+                lastQuery: string
+                tagSuggestions: Tag[]
+                titleSuggestions: Array<{ title: string; count: number }>
+                onTagSelect: (tag: Tag) => void
+            }
+
+            // Simulate a load already completed for the current text: one
+            // unselected tag suggestion, and a single title that exactly
+            // matches "Shop" (does not yet satisfy the hide rule, tag present).
+            vm.lastQuery = 'Shop'
+            vm.tagSuggestions = [tagSuggestion]
+            vm.titleSuggestions = [{ title: 'Shop', count: 1 }]
+            vm.dropdownOpen = true
+            await nextTick()
+
+            // Selecting the only remaining tag suggestion synchronously fires
+            // the simulated parent's listener (removing it from `addedTagIds`
+            // via the `tags` prop) before onTagSelect()'s own nextTick() call
+            // is scheduled — reproducing production ordering. doAutocomplete()
+            // then takes the lastQuery === q early-return branch (no new
+            // request), but the hide rule must still be re-checked against the
+            // now-filtered tag list.
+            vm.onTagSelect(tagSuggestion)
+            await flushPromises()
+
+            expect(vm.dropdownOpen).toBe(false)
+        })
+
+        it('keeps a selected tag suggestion in the cache so it reappears if the chip is later removed', async () => {
+            // Regression: onTagSelect() must not mutate `tagSuggestions`
+            // directly. If it did, removing the tag afterwards via its chip
+            // (ChargeCreate/ChargeEdit's onTagRemoved) would never bring the
+            // suggestion back, because doAutocomplete()'s lastQuery === q
+            // guard blocks any refetch while the typed text is unchanged.
+            const tagSuggestion = makeTagSuggestion(32, 'shopping')
+
+            const wrapper = mountInputWithParent('Shop')
+            const vm = wrapper.vm as unknown as {
+                lastQuery: string
+                tagSuggestions: Tag[]
+                titleSuggestions: Array<{ title: string; count: number }>
+                filteredTagSuggestions: Tag[]
+                onTagSelect: (tag: Tag) => void
+            }
+
+            vm.lastQuery = 'Shop'
+            vm.tagSuggestions = [tagSuggestion]
+            vm.titleSuggestions = []
+            await nextTick()
+
+            expect(vm.filteredTagSuggestions.map(t => t.id)).toEqual([32])
+
+            // Select it — the simulated parent appends it to its own
+            // `selectedTags` and passes the new array back down via `tags`.
+            vm.onTagSelect(tagSuggestion)
+            await flushPromises()
+
+            expect(vm.filteredTagSuggestions).toEqual([])
+
+            // Remove it via its chip — the parent drops it from
+            // `selectedTags` without the typed text changing.
+            await wrapper.setProps({ tags: [] })
+
+            // The underlying suggestion cache must still contain the tag so
+            // it reappears immediately, with no refetch involved.
+            expect(vm.tagSuggestions.map(t => t.id)).toEqual([32])
+            expect(vm.filteredTagSuggestions.map(t => t.id)).toEqual([32])
+        })
+
+        it('re-evaluates the hide rule when the clicked title suggestion matches the current text exactly', async () => {
+            // localValue is already "Shop" — assigning the same value again is
+            // a no-op for the ref, so the `localValue` watcher never fires.
+            // onTitleSelect() must fall back to calling doAutocomplete()
+            // directly so the lastQuery === q early-return path still re-runs
+            // the hide check.
+            const wrapper = mountInput('Shop')
+            const vm = wrapper.vm as unknown as {
+                dropdownOpen: boolean
+                lastQuery: string
+                tagSuggestions: Tag[]
+                titleSuggestions: Array<{ title: string; count: number }>
+                onTitleSelect: (title: string) => void
+            }
+
+            vm.lastQuery = 'Shop'
+            vm.tagSuggestions = []
+            vm.titleSuggestions = [{ title: 'Shop', count: 1 }]
+            vm.dropdownOpen = true
+            await nextTick()
+
+            vm.onTitleSelect('Shop')
+            await nextTick()
+
+            expect(vm.dropdownOpen).toBe(false)
         })
     })
 })


### PR DESCRIPTION
Closes #109

## Problem

Picking a charge title suggestion that was longer than the typed text made the autocomplete box vanish and reappear ~300ms later. `onTitleSelect()` set `dropdownOpen = false`, then assigning `localValue` fired the watcher → `doAutocomplete()` → debounced reload → reopened it. Type "Sho", click "Shop", and the box flickered shut before coming back with the new options.

## Changes

The dropdown now stays mounted through the reload and updates its options inline, exactly as it does while typing.

Auto-hiding is governed by an explicit rule instead of a bare "has any results" check: hide only when there are no unselected tag suggestions left **and** the title suggestions are either empty or a single exact match for the current input. Any unselected tag suggestion keeps the box open regardless of how many titles were found.

Two supporting fixes fell out of that:

- `doAutocomplete()`'s `lastQuery === q` early return re-evaluates the rule rather than leaving stale state behind. It is reached when re-clicking an option identical to the typed text, and via `onTagSelect()`.
- `onTagSelect()` defers its re-check to `nextTick()` so `props.tags` has round-tripped, which keeps the suggestion cache immutable. Mutating the cache to work around the timing would have stranded the suggestion permanently if the tag were later removed via its chip without the query changing.

## Verification

- **Unit** — 7 new tests in `ChargeTitleFormInput.spec.ts`, including an emission-sequence assertion (`dropdown-open-change` must emit `[[true]]` with no `false` between selection and reload) and a cache-integrity regression test asserting on the raw suggestion cache after a select-then-remove cycle. Full suite: 695 passed / 82 files.
- **E2E** — new `CC-12` in `charges-create.spec.ts` drives the real flow in a browser: types a genuine prefix, clicks the longer suggestion, and asserts the listbox DOM node survives the reload via `isConnected` on a handle captured before the click. A retrying `toBeVisible()` cannot detect a flicker; node identity can. Verified falsifiable — `CC-12` fails against the pre-fix component and passes against the fix.
- **Regression sweep** — full Playwright suite, both projects, `--workers=1`: 161/194 passed. All 33 failures accounted for and unrelated: 5 filter-calendar failures reproduce identically on clean `master`, and the other 28 were transient local-API 503s on seeding calls that all re-ran green.
- `npm run type-check` clean; `npm run lint` 0 errors (52 pre-existing advisory warnings unchanged).