### PR TITLE
fix(frontend): retry 2xx responses whose body was lost in transit

### DIFF
--- a/src/api/__tests__/client.spec.ts
+++ b/src/api/__tests__/client.spec.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import axios, { AxiosError, type AxiosInstance, type AxiosResponse, type InternalAxiosRequestConfig } from 'axios'
-import { apiCall, CsrfError, createAxiosInstance, REQUEST_TIMEOUT_MS, RETRY_MAX_ATTEMPTS } from '../client'
+import {
+    apiCall,
+    CsrfError,
+    createAxiosInstance,
+    MalformedResponseError,
+    REQUEST_TIMEOUT_MS,
+    RETRY_MAX_ATTEMPTS,
+} from '../client'
 
 vi.mock('@/shared/links', () => ({
     webSiteLink: (path: string) => `https://website.test${path}`,
@@ -267,6 +274,168 @@ describe('withTransportRetry (via apiCall)', () => {
         await vi.runAllTimersAsync()
         await assertion
         expect(fn).toHaveBeenCalledTimes(RETRY_MAX_ATTEMPTS)
+    })
+})
+
+// Swaps the adapter on a real createAxiosInstance so responses pass through axios'
+// own JSON transform before reaching the interceptors, as they do in the browser.
+function instanceWithResponses(responses: Array<Partial<AxiosResponse>>): {
+    instance: AxiosInstance
+    attempts: () => number
+} {
+    const instance = createAxiosInstance()
+    let attempts = 0
+    instance.defaults.adapter = async (config) => {
+        const spec = responses[Math.min(attempts, responses.length - 1)]
+        attempts++
+        return {
+            status: 200,
+            statusText: 'OK',
+            headers: {},
+            data: undefined,
+            ...spec,
+            config,
+        } as AxiosResponse
+    }
+    return { instance, attempts: () => attempts }
+}
+
+const JSON_HEADERS = { 'content-type': 'application/json; charset=utf-8' }
+const PROFILE_BODY = '{"data":{"id":1,"name":"Jane"}}'
+
+describe('malformed response detection', () => {
+    it('rejects a 200 JSON response whose body never arrived', async () => {
+        const { instance } = instanceWithResponses([{ headers: JSON_HEADERS, data: '' }])
+
+        const caught = await instance.get('/api/profile').catch((e: unknown) => e)
+
+        expect(caught).toBeInstanceOf(MalformedResponseError)
+        expect((caught as MalformedResponseError).message).toContain('empty body on a JSON response')
+        expect((caught as MalformedResponseError).status).toBe(200)
+        expect((caught as MalformedResponseError).method).toBe('get')
+    })
+
+    it('rejects a 200 JSON response whose body was cut short', async () => {
+        const { instance } = instanceWithResponses([{ headers: JSON_HEADERS, data: '{"data":{"id":1,' }])
+
+        const caught = await instance.get('/api/profile').catch((e: unknown) => e)
+
+        expect(caught).toBeInstanceOf(MalformedResponseError)
+        expect((caught as MalformedResponseError).message).toContain('unparseable JSON body')
+    })
+
+    it('attaches the response trace id to the error', async () => {
+        const { instance } = instanceWithResponses([
+            { headers: { ...JSON_HEADERS, 'x-ct-trace-id': 'trace-truncated' }, data: '' },
+        ])
+
+        const caught = await instance.get('/api/profile').catch((e: unknown) => e)
+
+        expect((caught as Record<string, unknown>).ctTraceId).toBe('trace-truncated')
+    })
+
+    it('accepts an empty 200 with no content type (Spiral $response->create(200))', async () => {
+        // DELETE wallet/tag/limit/charge and PATCH wallet user all answer this way.
+        const { instance } = instanceWithResponses([{ headers: {}, data: '' }])
+
+        await expect(instance.delete('/api/wallets/1')).resolves.toMatchObject({ status: 200 })
+    })
+
+    it('accepts an empty 200 with a text content type (gateway /csrf, /live)', async () => {
+        const { instance } = instanceWithResponses([
+            { headers: { 'content-type': 'text/plain; charset=utf-8' }, data: '' },
+        ])
+
+        await expect(instance.get('/csrf')).resolves.toMatchObject({ status: 200 })
+    })
+
+    it('accepts a well-formed JSON body', async () => {
+        const { instance } = instanceWithResponses([{ headers: JSON_HEADERS, data: PROFILE_BODY }])
+
+        const response = await instance.get('/api/profile')
+
+        expect(response.data).toEqual({ data: { id: 1, name: 'Jane' } })
+    })
+
+    it('leaves a non-json responseType alone even when the body is a string', async () => {
+        const { instance } = instanceWithResponses([{ headers: JSON_HEADERS, data: '' }])
+
+        await expect(instance.get('/api/export', { responseType: 'text' })).resolves.toMatchObject({ status: 200 })
+    })
+
+    it('does not flag a HEAD request, which has no body by definition', async () => {
+        const { instance } = instanceWithResponses([{ headers: JSON_HEADERS, data: '' }])
+
+        await expect(instance.head('/api/profile')).resolves.toMatchObject({ status: 200 })
+    })
+})
+
+describe('malformed response retry (via apiCall)', () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+        vi.clearAllMocks()
+    })
+
+    it('retries a GET whose body was lost and succeeds on the next attempt', async () => {
+        const { instance, attempts } = instanceWithResponses([
+            { headers: JSON_HEADERS, data: '' },
+            { headers: JSON_HEADERS, data: PROFILE_BODY },
+        ])
+
+        const promise = apiCall(async (client) => {
+            const res = await client.get('/api/profile')
+            return res.data.data
+        }, () => instance)
+        await vi.runAllTimersAsync()
+
+        await expect(promise).resolves.toEqual({ id: 1, name: 'Jane' })
+        expect(attempts()).toBe(2)
+    })
+
+    it('gives up after RETRY_MAX_ATTEMPTS when the body never arrives', async () => {
+        const { instance, attempts } = instanceWithResponses([{ headers: JSON_HEADERS, data: '' }])
+
+        const promise = apiCall((client) => client.get('/api/profile'), () => instance)
+        const assertion = expect(promise).rejects.toBeInstanceOf(MalformedResponseError)
+        await vi.runAllTimersAsync()
+        await assertion
+
+        expect(attempts()).toBe(RETRY_MAX_ATTEMPTS)
+    })
+
+    it('does NOT retry a POST whose body was lost — the write may have landed', async () => {
+        const { instance, attempts } = instanceWithResponses([{ headers: JSON_HEADERS, data: '' }])
+
+        const promise = apiCall((client) => client.post('/api/wallets', { name: 'Main' }), () => instance)
+        const assertion = expect(promise).rejects.toBeInstanceOf(MalformedResponseError)
+        await vi.runAllTimersAsync()
+        await assertion
+
+        expect(attempts()).toBe(1)
+    })
+
+    it('recovers the incident case: a model parser no longer sees an undefined payload', async () => {
+        // 2026-07-22: /api/profile answered 200 with a lost body, so User.from threw a
+        // plain Error on undefined and withTransportRetry refused to retry it.
+        const { instance } = instanceWithResponses([
+            { headers: JSON_HEADERS, data: '' },
+            { headers: JSON_HEADERS, data: PROFILE_BODY },
+        ])
+
+        const promise = apiCall(async (client) => {
+            const res = await client.get('/api/profile')
+            if (!res.data.data || typeof res.data.data !== 'object') {
+                throw new Error('User.from: expected object')
+            }
+            return res.data.data
+        }, () => instance)
+        await vi.runAllTimersAsync()
+
+        await expect(promise).resolves.toEqual({ id: 1, name: 'Jane' })
     })
 })
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError, type AxiosInstance } from 'axios'
+import axios, { AxiosError, type AxiosInstance, type AxiosResponse } from 'axios'
 import { webSiteLink } from '@/shared/links'
 import { getEnv } from '@/shared/env'
 
@@ -11,10 +11,11 @@ function extractTraceId(headers: unknown): string | undefined {
     return typeof value === 'string' && value.length > 0 ? value : undefined
 }
 
+// First writer wins — the failing response's own trace ID beats apiCall's last-seen fallback.
 function attachTraceId(error: unknown, traceId: string | undefined): void {
-    if (traceId && error && typeof error === 'object') {
-        Object.assign(error, { ctTraceId: traceId })
-    }
+    if (!traceId || !error || typeof error !== 'object') return
+    if ((error as { ctTraceId?: unknown }).ctTraceId) return
+    Object.assign(error, { ctTraceId: traceId })
 }
 
 export class CsrfError extends Error {
@@ -23,6 +24,48 @@ export class CsrfError extends Error {
         this.name = 'CsrfError'
         this.stack = cause.stack
     }
+}
+
+/**
+ * A 2xx response whose body was lost or cut short in transit. XHR reports that as a
+ * successful status with an empty payload rather than a network error, so it has to be
+ * detected from the body and retried like any other transport failure.
+ */
+export class MalformedResponseError extends Error {
+    readonly status: number
+    readonly method: string
+
+    constructor(message: string, response: AxiosResponse) {
+        super(message)
+        this.name = 'MalformedResponseError'
+        this.status = response.status
+        this.method = response.config?.method?.toLowerCase() ?? ''
+    }
+}
+
+const JSON_CONTENT_TYPE = /^application\/([\w.+-]+\+)?json\b/i
+
+function isJsonContentType(headers: unknown): boolean {
+    if (!headers || typeof headers !== 'object') return false
+    const value = (headers as Record<string, unknown>)['content-type']
+    return typeof value === 'string' && JSON_CONTENT_TYPE.test(value.trim())
+}
+
+/** Why a successful response is unusable, or null when it is fine. */
+function malformedBodyReason(response: AxiosResponse): string | null {
+    if (response.config?.method?.toLowerCase() === 'head') return null
+
+    const responseType = response.config?.responseType
+    if (responseType !== undefined && responseType !== 'json') return null
+
+    // Gated on the content type: endpoints that legitimately answer with an empty 200
+    // (Spiral's $response->create(200), gateway /csrf) declare no content type at all.
+    if (!isJsonContentType(response.headers)) return null
+
+    // axios leaves `data` a string only when the body was empty or JSON.parse threw.
+    if (typeof response.data !== 'string') return null
+
+    return response.data.length === 0 ? 'empty body on a JSON response' : 'unparseable JSON body'
 }
 
 // Per-attempt cap. Kept below the worst-case (attempts × timeout + backoff) so a
@@ -35,6 +78,8 @@ const RETRY_BACKOFF_FACTOR = 3               // base delays 400ms, 1200ms (±50%
 const SAFE_METHODS = new Set(['get', 'head', 'options'])
 
 function isRetryableTransportError(error: unknown): boolean {
+    // Lost body → same idempotency rule as a dropped connection
+    if (error instanceof MalformedResponseError) return SAFE_METHODS.has(error.method)
     if (!(error instanceof AxiosError)) return false
     if (error.response) return false                       // got an HTTP status → not transport
     if (error.code === 'ERR_CANCELED') return false        // user/abort cancelled
@@ -71,7 +116,18 @@ export function createAxiosInstance(): AxiosInstance {
     })
 
     instance.interceptors.response.use(
-        (response) => response,
+        (response) => {
+            const reason = malformedBodyReason(response)
+            if (reason === null) return response
+
+            const error = new MalformedResponseError(
+                `${response.config?.method?.toUpperCase() ?? 'GET'} ${response.config?.url ?? ''}`.trim() +
+                    ` returned HTTP ${response.status} with ${reason}`,
+                response,
+            )
+            attachTraceId(error, extractTraceId(response.headers))
+            return Promise.reject(error)
+        },
         (error: unknown) => {
             if (error instanceof AxiosError && error.response) {
                 if (error.response.status === 401) {


### PR DESCRIPTION
## Problem

Reported 2026-07-22 from iOS Safari on LTE: the Wallets page showed **"Unable to load your profile. Please try again."** with `Error: User.from: expected object`.

`GET /api/profile` returned **200**. Traefik logged `200 347` for both the failing request and the successful retry 15 seconds later — byte-identical, so gzip had the same 519-byte JSON input both times. The response was correct on the wire; the body was lost between Traefik and the handset.

XHR reports a lost or truncated body as a successful status with an empty payload rather than as a network error. axios then leaves `res.data` as the raw unparsed string, because its JSON transform swallows the parse failure on an empty or malformed body. So `res.data.data` is `undefined`, `User.from` throws a plain `Error`, and:

```ts
function isRetryableTransportError(error: unknown): boolean {
    if (!(error instanceof AxiosError)) return false
    ...
}
```

`withTransportRetry` never retried it. A transient delivery glitch reached the user as a permanent, cryptic failure.

## Change

A response interceptor rejects a 2xx whose body did not survive, with a new `MalformedResponseError`. `isRetryableTransportError` recognises it, so it flows through the **existing** retry machinery unchanged — same `RETRY_MAX_ATTEMPTS` (3), same 400ms/1200ms ±50% jittered backoff, same 15s per-attempt timeout, same safe-method gate. A POST whose response body was lost is still not replayed: the write may have landed.

Also:
- `attachTraceId` is now first-writer-wins, so the trace ID from the response that actually failed is not overwritten by `apiCall`'s last-seen fallback.
- The error message reads `GET /api/profile returned HTTP 200 with empty body on a JSON response`. `describeError` renders that plus the trace ID in the "Show details" panel, instead of `User.from: expected object`.

## Why this cannot flag a legitimate empty 200

The check only fires when the response declares a JSON content type **and** axios left `data` as a string.

16 API endpoints answer 200 with no body (`DELETE` wallet/tag/limit/charge, `PATCH` wallet user, and others). All of them go through Spiral's `$this->response->create(200)`, which calls `createResponse($code)` and sets **no** `Content-Type` at all — so the gate cannot fire on them. Same for the gateway's `/csrf`, `/live` and `/ready`. `HEAD` requests and non-`json` `responseType` are excluded explicitly. All four cases have tests.

## Verification

707/707 unit tests pass (13 new in `client.spec.ts`), `vue-tsc` clean on `tsconfig.app.json` and `tsconfig.vitest.json`, `npm run lint` reports 0 errors.

The new tests swap the adapter on a real `createAxiosInstance()`, so responses pass through axios' own JSON transform before reaching the interceptors — the same path a truncated body takes in the browser — and the retry tests assert the adapter was invoked exactly the expected number of times.

## Related

Two defects found during the same investigation, both filed separately and neither a cause of this one:

- cash-track/gateway#44 — concurrent requests each fire their own token refresh; six-way stampedes ~2–3× a day.
- cash-track/api#207 — `AuthAwareController` leaves `$user` uninitialized instead of failing with 401.
