### PR TITLE
fix(frontend): repair calendar E2E selectors after the Nuxt UI 4.5.1 bump

### DIFF
--- a/e2e/charges-charts.spec.ts
+++ b/e2e/charges-charts.spec.ts
@@ -10,7 +10,7 @@ import {
     label, labelStrings,
     routeError, routeJson,
     createWalletViaApi, deleteWalletViaApi,
-    wallet, assertNoErrorLeak,
+    calendar, pickFirstAvailableDate, wallet, assertNoErrorLeak,
 } from './support'
 
 // ── Local selectors ──────────────────────────────────────────────────────────
@@ -46,10 +46,6 @@ const incomeHeading = (page: import('@playwright/test').Page) =>
 // Calendar icon button for date-from filter
 const filterFromCalendarBtn = (page: import('@playwright/test').Page) =>
     page.getByRole('button', { name: label('charges.filterInputFrom') })
-
-// Available calendar date cells
-const availableCalendarCells = (page: import('@playwright/test').Page) =>
-    page.locator('td[role="gridcell"]:not([data-disabled])')
 
 test.describe('S18 — Charges Charts', () => {
 
@@ -189,8 +185,8 @@ test.describe('S18 — Charges Charts', () => {
 
             // Pick a date from the calendar to trigger filter-change → reload()
             await filterFromCalendarBtn(page).click()
-            await expect(page.locator('[role="grid"]').first()).toBeVisible({ timeout: 5000 })
-            await availableCalendarCells(page).first().click()
+            await expect(calendar.grid(page)).toBeVisible({ timeout: 5000 })
+            await pickFirstAvailableDate(page)
 
             // Chart reload should fire with date-from param
             const graphRequest = await graphReloadPromise

--- a/e2e/charges-create.spec.ts
+++ b/e2e/charges-create.spec.ts
@@ -5,7 +5,7 @@ import {
     label, labelStrings,
     routeError, route422, routeJson,
     createWalletViaApi, createTagViaApi, createChargeViaApi, deleteWalletViaApi, deleteTagViaApi,
-    charge, assertNoErrorLeak,
+    calendar, charge, assertNoErrorLeak,
 } from './support'
 
 // ── Local selectors ──────────────────────────────────────────────────────────
@@ -238,17 +238,26 @@ test.describe('S8 — Charge Create', () => {
                 timeout: 5000,
             })
 
-            // Calendar popover button should be visible (the leading slot)
-            const calIconBtn = page.locator('form button').filter({
-                has: page.locator('.i-lucide-calendar'),
-            }).first()
-            if (await calIconBtn.isVisible()) {
-                await calIconBtn.click()
-                // Calendar grid should appear
-                await expect(page.locator('[data-slot="calendar"]').or(
-                    page.getByRole('grid').first()
-                )).toBeVisible({ timeout: 5000 })
-            }
+            // Calendar popover button in the trailing slot. Nuxt UI renders the icon as an
+            // inline <svg>, not an `.i-lucide-calendar` class, so match the popover trigger
+            // itself — it is the only aria-haspopup="dialog" in the form, and it only exists
+            // once "Set date" has been clicked.
+            const calIconBtn = calendar.triggerInForm(page)
+            await expect(calIconBtn).toBeVisible({ timeout: 5000 })
+            await calIconBtn.click()
+
+            // Calendar grid should appear, capped at today by :max-value — every date after
+            // today is [data-disabled], so the last selectable cell is today itself. Cell
+            // triggers carry data-value="YYYY-MM-DD".
+            await expect(calendar.grid(page)).toBeVisible({ timeout: 5000 })
+            const today = new Date()
+            const todayValue = [
+                today.getFullYear(),
+                String(today.getMonth() + 1).padStart(2, '0'),
+                String(today.getDate()).padStart(2, '0'),
+            ].join('-')
+            await expect(calendar.availableCells(page).last().locator('[data-value]'))
+                .toHaveAttribute('data-value', todayValue)
 
             await assertNoErrorLeak(page)
         } finally {

--- a/e2e/charges-filter.spec.ts
+++ b/e2e/charges-filter.spec.ts
@@ -2,13 +2,13 @@
 // CF-01..CF-05: date-from/date-to inputs, calendar popover, active badges, clear, refetch params
 //
 // UInputDate renders as role="group" with role="spinbutton" segments — NOT role="textbox".
-// The UCalendar grid (role="grid") opens via UPopover on the calendar icon button.
+// The UCalendar grid ([data-slot="grid"]) opens via UPopover on the calendar icon button.
 // Date entry is most reliable via the calendar popover: click the icon, pick a gridcell.
 import { test, expect } from '@playwright/test'
 import {
     label,
     createWalletViaApi, deleteWalletViaApi, createChargeViaApi, deleteChargeViaApi,
-    wallet, assertNoErrorLeak,
+    calendar, pickFirstAvailableDate, wallet, assertNoErrorLeak,
 } from './support'
 
 // ── Local selectors ──────────────────────────────────────────────────────────
@@ -28,14 +28,6 @@ const filterFromCalendarBtn = (page: import('@playwright/test').Page) =>
 const filterToCalendarBtn = (page: import('@playwright/test').Page) =>
     page.getByRole('button', { name: label('charges.filterInputTo') })
 
-// UCalendar renders role="grid" inside the popover
-const calendarGrid = (page: import('@playwright/test').Page) =>
-    page.locator('[role="grid"]').first()
-
-// Available (non-disabled) calendar date cells
-const availableCalendarCells = (page: import('@playwright/test').Page) =>
-    page.locator('td[role="gridcell"]:not([data-disabled])')
-
 // The clear (x) button inside a badge: aria-label = wallets.clear
 const clearButtons = (page: import('@playwright/test').Page) =>
     page.getByRole('button', { name: label('wallets.clear') })
@@ -44,14 +36,16 @@ const clearButtons = (page: import('@playwright/test').Page) =>
 const filterBadges = (page: import('@playwright/test').Page) =>
     page.locator('span, div').filter({ hasText: /\d{4}-\d{2}-\d{2}/ })
 
-// Helper: open the date-from calendar popover and click the first available date
+// Helper: open a calendar popover and pick the first selectable date.
+// pickFirstAvailableDate resolves only once Reka marks the day selected, so callers can
+// assert on the badge / refetch straight away without racing the click.
 async function pickDateFromCalendar(
     page: import('@playwright/test').Page,
     calendarBtn: import('@playwright/test').Locator,
 ) {
     await calendarBtn.click()
-    await expect(calendarGrid(page)).toBeVisible({ timeout: 5000 })
-    await availableCalendarCells(page).first().click()
+    await expect(calendar.grid(page)).toBeVisible({ timeout: 5000 })
+    await pickFirstAvailableDate(page)
 }
 
 test.describe('S14 — Charges Filter', () => {
@@ -80,7 +74,7 @@ test.describe('S14 — Charges Filter', () => {
     })
 
     // CF-02 — Calendar popover opens when clicking the calendar icon
-    test('CF-02 @smoke clicking calendar icon opens UCalendar with a role=grid', async ({ request, page }) => {
+    test('CF-02 @smoke clicking calendar icon opens the UCalendar grid', async ({ request, page }) => {
         const w = await createWalletViaApi(request, { name: `E2E CF02 ${Date.now()}` })
         try {
             await page.goto(`/wallets/${w.id}`)
@@ -90,15 +84,15 @@ test.describe('S14 — Charges Filter', () => {
 
             // Click the calendar icon for date-from → UCalendar grid appears
             await filterFromCalendarBtn(page).click()
-            await expect(calendarGrid(page)).toBeVisible({ timeout: 5000 })
+            await expect(calendar.grid(page)).toBeVisible({ timeout: 5000 })
 
             // Dismiss
             await page.keyboard.press('Escape')
-            await expect(calendarGrid(page)).not.toBeVisible({ timeout: 3000 })
+            await expect(calendar.grid(page)).not.toBeVisible({ timeout: 3000 })
 
             // Repeat for date-to
             await filterToCalendarBtn(page).click()
-            await expect(calendarGrid(page)).toBeVisible({ timeout: 5000 })
+            await expect(calendar.grid(page)).toBeVisible({ timeout: 5000 })
 
             await assertNoErrorLeak(page)
         } finally {

--- a/e2e/support/selectors.ts
+++ b/e2e/support/selectors.ts
@@ -35,6 +35,30 @@ export const overlay = {
         page.getByRole('dialog').getByRole('button', { name: label('common.delete') }),
 }
 
+// ── UCalendar popover (Reka Calendar, portalled) ─────────────────────────--
+// Since Nuxt UI 4.5.1 the grid table renders as <table role="application"
+// data-slot="grid"> — there is NO role="grid" anywhere in the DOM, so match the
+// data-slot instead (structural, and stable across Reka role changes). Date cells
+// still carry role="gridcell", which is why only the grid gate ever broke.
+export const calendar = {
+    grid: (page: Page): Locator => page.locator('[data-slot="grid"]').first(),
+    // Selectable date cells: not disabled (ChargeCreate caps the calendar at today via
+    // :max-value) AND not an adjacent-month padding day. The 6-week grid pads with
+    // [data-outside-view] days, and clicking one both selects the date and NAVIGATES the
+    // grid to that month — the re-render then races whatever the test asserts next.
+    // Staying in-view keeps the click a pure selection.
+    availableCells: (page: Page): Locator =>
+        page.locator('td[role="gridcell"]:not([data-disabled]):not(:has([data-outside-view]))'),
+    // The interactive element inside a cell — the <td> is only a wrapper, the click
+    // handler lives on this div. Carries data-value="YYYY-MM-DD".
+    cellTrigger: (cell: Locator): Locator => cell.locator('[data-reka-calendar-cell-trigger]'),
+    // The UPopover trigger that opens a calendar. In ChargesFilter the buttons carry
+    // i18n aria-labels (charges.filterInputFrom/To) — prefer those; ChargeCreate's has
+    // no accessible name, so scope by form and match the popover trigger attribute.
+    triggerInForm: (page: Page): Locator =>
+        page.locator('form button[aria-haspopup="dialog"]').first(),
+}
+
 // ── Wallets list + detail ────────────────────────────────────────────────--
 export const wallet = {
     newWalletLink: (page: Page): Locator =>
@@ -116,6 +140,32 @@ export const settings = {
         page.getByLabel(label('securitySettings.newPasswordConfirmation')),
     updatePassword: (page: Page): Locator =>
         page.getByRole('button', { name: label('securitySettings.updatePassword') }),
+}
+
+/**
+ * Pick the first selectable day in an already-open UCalendar popover, and return its
+ * `YYYY-MM-DD` value. Resolves only once Reka has marked the day selected, so callers
+ * can assert on the consequences (badge, refetch) without racing the click.
+ *
+ * The click is retried until the selection sticks. Under full-suite load a click on the
+ * portalled popover is occasionally not delivered to the cell trigger: every Playwright
+ * actionability check passes, the popover stays open, and no date is set — the date-from
+ * segments still read mm/dd/yyyy. It reproduces roughly one full run in three and never
+ * in isolation (0/40 in a tight loop), and the badge is pure local state (`v-if="dateFrom"`
+ * in ChargesFilter.vue) so no API call is involved. Selecting a day is idempotent —
+ * re-clicking an already-selected day leaves it selected — so re-issuing the click is safe
+ * and makes this helper's contract ("a date is picked") actually hold.
+ */
+export async function pickFirstAvailableDate(page: Page): Promise<string> {
+    const { expect } = await import('@playwright/test')
+    const cell = calendar.availableCells(page).first()
+
+    await expect(async () => {
+        await calendar.cellTrigger(cell).click()
+        await expect(cell).toHaveAttribute('aria-selected', 'true', { timeout: 1000 })
+    }).toPass({ timeout: 10000 })
+
+    return (await calendar.cellTrigger(cell).getAttribute('data-value')) ?? ''
 }
 
 /** Body never shows a raw/unknown error — call in every page test (§3.4). */


### PR DESCRIPTION
Fixes #141

## What broke

Nuxt UI 4.5.1 (Reka UI) dropped `role="grid"` from `UCalendar`. The grid table now renders as `<table role="application" data-slot="grid">` — there is no `role="grid"` anywhere in the DOM. Date cells still carry `role="gridcell"`, which is why only the grid gate broke and the five `@smoke` cases (CF-02..CF-05, CH-05) all failed the same way: a timeout waiting on `[role="grid"]` after clicking the "Date from" calendar button.

## What changed

Selectors match `[data-slot="grid"]` instead — structural, and stable across Reka role changes. They move into a shared `calendar` group in `e2e/support/selectors.ts` (`grid`, `availableCells`, `cellTrigger`, `triggerInForm`) so `charges-filter` and `charges-charts` stop re-deriving them. The stale comment at `charges-filter.spec.ts:5` is corrected and CF-02 is retitled — it no longer asserts a `role=grid`.

### The sweep found a third stale site

`charges-create.spec.ts` CC-06 was not named in the issue, and its calendar assertion was doubly dead:

- the block was guarded by `if (await calIconBtn.isVisible())` where `calIconBtn` matched `.i-lucide-calendar` — Nuxt UI renders icons as inline `<svg>`, so that locator never matched and the guard silently skipped everything inside;
- both branches of the assertion inside targeted elements that do not exist (`[data-slot="calendar"]` → 0 matches, `getByRole('grid')` → 0 matches).

It now asserts what its comment always claimed — that `:max-value` caps the calendar at today — deterministically, via `data-value` on the last selectable cell.

## Two fixes to the date-picking path

Both surfaced while verifying the above.

**Adjacent-month padding days are excluded.** The 6-week (42-cell) grid pads with `[data-outside-view]` days. Clicking one both selects the date *and* navigates the grid to that month, and the re-render races whatever the test asserts next.

**The cell click is retried.** After the selector fix CF-04 still failed in roughly 1 full-suite run in 3, and never in isolation (0/40 in a tight open→click loop). Evidence: the failure snapshot showed the popover still open with the date segments reading `mm/dd/yyyy` and no badge; the badge is pure local state (`v-if="dateFrom"` in `ChargesFilter.vue`), so no API call is involved; and cell geometry is concentric at every viewport (td 36px / trigger 32px), so the click point is correct. The click simply is not always delivered to the cell trigger under load, even though every Playwright actionability check passes.

`pickFirstAvailableDate()` clicks the trigger and re-issues the click inside `expect(...).toPass()` until the cell reports `aria-selected="true"`. Selecting a day is idempotent, so re-clicking is safe. Confirmed with a negative control: swallowing the first click via a capturing `addInitScript` listener makes the old single-click path fail with CF-04's exact error signature, and the helper recovers.

## Verification

`type-check` clean · `lint` 0 errors (50 pre-existing advisory warnings) · unit 707/707 · `build` clean · **full E2E 194/194 across three consecutive runs** — CF-04 previously failed in one of two.

Test-only change; no application code touched.