### PR TITLE
fix(frontend): show passkey name in the delete confirmation modal

### DIFF
--- a/e2e/settings-security.spec.ts
+++ b/e2e/settings-security.spec.ts
@@ -294,6 +294,12 @@ test.describe('S16 — Settings: Security tab', () => {
         // Confirm modal should open
         await expect(overlay.dialog(page)).toBeVisible({ timeout: 5000 })
 
+        // …and its description must name the passkey being deleted. The message
+        // (passkeySettings.deleteConfirm) carries a {name} placeholder, which vue-i18n
+        // interpolates ONLY when passed as a named param — a post-hoc string replace
+        // silently yields empty quotes (issue #133).
+        await expect(overlay.dialog(page)).toContainText('E2E Test Key', { timeout: 5000 })
+
         // Confirm the deletion (common.delete button in the dialog)
         await overlay.confirmDelete(page).click()
 

--- a/src/components/settings/passkeys/PasskeyItem.vue
+++ b/src/components/settings/passkeys/PasskeyItem.vue
@@ -39,7 +39,7 @@ const usedAt = computed(() => {
 })
 
 const deleteConfirmDescription = computed(() =>
-    t('passkeySettings.deleteConfirm').replace(/\{name\}/g, props.passkey.name),
+    t('passkeySettings.deleteConfirm', { name: props.passkey.name }),
 )
 
 async function onDeleteConfirmed() {

--- a/src/components/settings/passkeys/__tests__/PasskeyItem.spec.ts
+++ b/src/components/settings/passkeys/__tests__/PasskeyItem.spec.ts
@@ -2,17 +2,19 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import PasskeyItem from '../PasskeyItem.vue'
+import ConfirmModal from '@/components/Shared/ConfirmModal.vue'
 import { Passkey } from '@/api/models/passkey'
 
-const { mockDeletePasskey } = vi.hoisted(() => ({
+const { mockDeletePasskey, mockT } = vi.hoisted(() => ({
     mockDeletePasskey: vi.fn(),
+    mockT: vi.fn((key: string) => key),
 }))
 
 const mockLocale = { value: 'en' }
 
 vi.mock('vue-i18n', () => ({
     useI18n: () => ({
-        t: (key: string) => key,
+        t: mockT,
         locale: mockLocale,
     }),
 }))
@@ -55,6 +57,7 @@ describe('PasskeyItem', () => {
     beforeEach(() => {
         setActivePinia(createPinia())
         vi.clearAllMocks()
+        mockT.mockImplementation((key: string) => key)
         mockLocale.value = 'en'
     })
 
@@ -73,6 +76,22 @@ describe('PasskeyItem', () => {
         const wrapper = mount(PasskeyItem, { ...globalStubs, props: { passkey: makePasskey(usedAt) } })
         expect(wrapper.text()).not.toContain('passkeySettings.usedAtNever')
         expect(wrapper.text()).toContain('passkeySettings.used')
+    })
+
+    it('passes the passkey name to the confirm description as a named param', () => {
+        // Param-aware t mock: proves the name reaches t() as an interpolation param
+        // rather than being post-hoc string-replaced (vue-i18n eats {name} first).
+        mockT.mockImplementation((key: string, params?: Record<string, unknown>) =>
+            params ? `${key}:${JSON.stringify(params)}` : key,
+        )
+
+        const wrapper = mount(PasskeyItem, { ...globalStubs, props: { passkey: makePasskey() } })
+        const modal = wrapper.findComponent(ConfirmModal)
+
+        expect(modal.exists()).toBe(true)
+        expect(modal.props('description')).toBe(
+            'passkeySettings.deleteConfirm:{"name":"My YubiKey"}',
+        )
     })
 
     it('opens confirm modal when delete button is clicked', async () => {


### PR DESCRIPTION
Closes #133

## Problem

Deleting a passkey opened a confirmation modal reading `Are you sure you want to delete PassKey ""?` — the name was always missing.

## Cause

`PasskeyItem.vue` built the description as:

```ts
t('passkeySettings.deleteConfirm').replace(/\{name\}/g, props.passkey.name)
```

vue-i18n's message compiler owns `{…}` placeholders. Calling `t()` with no params resolves `{name}` to the **empty string**, so by the time `.replace()` ran there was no placeholder left to match — it was a no-op on an already-emptied string.

## Fix

```ts
t('passkeySettings.deleteConfirm', { name: props.passkey.name })
```

Every other interpolated message in the app (`wallets.deletingConfirm`, `charges.deletingConfirm`, `tags.deletingConfirm`, the router's `namedTitle`) already used named params; this was the only outlier.

## Why it shipped uncaught

Both existing tests were structurally blind to it:

- The unit spec's `t` mock was `(key) => key`, which returns the same value with or without the bug — the key contains no `{name}` either way. Now uses the param-aware mock convention from `ChargeItem.spec.ts` and asserts the serialized params.
- `SS-08` clicked through the whole delete flow but only checked that the dialog opened, never its text. It now asserts the passkey name is present.

Both new assertions were verified against a temporarily re-introduced bug and fail without the fix.