### PR TITLE
fix(charges): keep timeline connector inside its row on mobile

### DIFF
--- a/e2e/responsive.mobile.spec.ts
+++ b/e2e/responsive.mobile.spec.ts
@@ -372,4 +372,46 @@ test.describe('S21 — Responsive / Mobile', () => {
         }
     })
 
+    // RM-10 — Charge timeline connector must not double up between adjacent rows
+    // (issue #108: ChargeItem's timeline column had an unconditional -my-2 cancelling a
+    // `sm:`-only py-2, so below sm it overflowed 8px past each edge and neighbouring
+    // 10%-opacity lines overlapped, compositing to ~19% — a clipped-looking border).
+    test('RM-10 charge timeline connector does not overlap between adjacent rows', async ({ request, page }) => {
+        const stamp = Date.now()
+        const w = await createWalletViaApi(request, { name: `E2E RM10 ${stamp}` })
+        try {
+            // Two charges on the same day land in one group → adjacent sibling rows.
+            await createChargeViaApi(request, w.id, { title: `E2E RM10 first ${stamp}` })
+            await createChargeViaApi(request, w.id, { title: `E2E RM10 second ${stamp}` })
+
+            await page.goto(`/wallets/${w.id}`)
+            await expect(wallet.detailHeading(page)).toBeVisible({ timeout: 10000 })
+            await expect(page.getByText(`E2E RM10 second ${stamp}`)).toBeVisible({ timeout: 10000 })
+
+            // ChargeItem root is the only .items-stretch in the app; its first child is
+            // the timeline column. Measure boxes rather than assert Tailwind classes.
+            const overflow = await page.evaluate(() => {
+                const rows = Array.from(document.querySelectorAll('.items-stretch'))
+                return rows.map(row => {
+                    const column = row.firstElementChild as HTMLElement | null
+                    if (!column) return null
+                    const r = row.getBoundingClientRect()
+                    const c = column.getBoundingClientRect()
+                    return { above: r.top - c.top, below: c.bottom - r.bottom }
+                })
+            })
+
+            expect(overflow.length).toBeGreaterThanOrEqual(2)
+            for (const box of overflow) {
+                expect(box).not.toBeNull()
+                expect(box!.above).toBeLessThanOrEqual(0.5)
+                expect(box!.below).toBeLessThanOrEqual(0.5)
+            }
+
+            await assertNoErrorLeak(page)
+        } finally {
+            await deleteWalletViaApi(request, w.id)
+        }
+    })
+
 })

--- a/src/components/wallets/charges/ChargeItem.vue
+++ b/src/components/wallets/charges/ChargeItem.vue
@@ -129,9 +129,11 @@ defineExpose({ fullDateTime, chargeTime })
         ]"
         @click="toggleExpand()"
     >
-        <!-- Timeline column: fixed width, centered icon + vertical line -->
-        <div class="flex flex-col items-center w-10 shrink-0 py-0 -my-2">
-            <div class="w-px h-[20px] bg-black/10 dark:bg-white/10" />
+        <!-- Timeline column. -my-2 cancels the row's own padding, so it must share its
+             breakpoint or the column overflows the row and neighbouring lines overlap.
+             The spacer aligns the icon to the title line at each breakpoint. -->
+        <div class="flex flex-col items-center w-10 shrink-0 sm:-my-2">
+            <div class="w-px h-3 sm:h-5 bg-black/10 dark:bg-white/10" />
             <button
                 type="button"
                 class="flex items-center justify-center size-7 rounded-full border-0 shrink-0 transition-colors"

--- a/src/components/wallets/charges/__tests__/ChargeItem.spec.ts
+++ b/src/components/wallets/charges/__tests__/ChargeItem.spec.ts
@@ -564,4 +564,39 @@ describe('ChargeItem', () => {
         expect(wrapper.emitted('updated')).toBeTruthy()
         expect(wrapper.emitted('updated')![0]).toEqual([charge])
     })
+
+    // Issue #108 — the timeline column's -my-2 only cancels the row's own padding, so
+    // both must share a breakpoint; otherwise the column overflows 8px past each edge
+    // on mobile and adjacent rows' lines overlap at double opacity.
+    describe('timeline column geometry (issue #108)', () => {
+        function timelineColumn(wrapper: ReturnType<typeof shallowMount>) {
+            return wrapper.find('.flex.flex-col.items-center.w-10')
+        }
+
+        it('gates the timeline negative margin on the same breakpoint as the row padding', () => {
+            const wrapper = shallowMount(ChargeItem, {
+                props: { charge: makeCharge({}), wallet: makeWallet() },
+            })
+
+            const rowClasses = wrapper.classes()
+            expect(rowClasses).toContain('sm:py-2')
+            expect(rowClasses).not.toContain('py-2')
+
+            const columnClasses = timelineColumn(wrapper).classes()
+            expect(columnClasses).toContain('sm:-my-2')
+            expect(columnClasses).not.toContain('-my-2')
+        })
+
+        it('offsets the icon by the row content padding at each breakpoint', () => {
+            const wrapper = shallowMount(ChargeItem, {
+                props: { charge: makeCharge({}), wallet: makeWallet() },
+            })
+
+            // Spacer must span column top → title top: py-3 (12px), plus the row's
+            // sm:py-2 once it applies (20px).
+            const spacer = timelineColumn(wrapper).find('div')
+            expect(spacer.classes()).toContain('h-3')
+            expect(spacer.classes()).toContain('sm:h-5')
+        })
+    })
 })


### PR DESCRIPTION
Closes #108

## Root cause

`ChargeItem`'s timeline column carried an unconditional `-my-2`, whose only job is to cancel the row's own vertical padding — and that padding is `sm:py-2`, i.e. breakpoint-gated.

At `sm`+ the two cancel out and the column's margin box lands exactly on the row's border box. Below `sm` there is no padding to cancel, so the column overflowed **8px past each edge**. Adjacent rows' `bg-black/10` connectors then overlapped over a 16px band, and two 10% layers composite to `255·0.9² = 206` against the normal `229` — which reads as the clipped/doubled border in the issue.

Measured on the reported screenshot before touching code: the darker bands are RGB **206** vs **229**, span **32 device px** (2× DPR → 16 CSS px = 8 + 8), and sit exactly on the row boundaries.

## Fix

- `py-0 -my-2` → `sm:-my-2` (the dead `py-0` is dropped)
- `h-[20px]` → `h-3 sm:h-5` — the spacer aligning the arrow icon to the title line has to compensate for the row padding, so it needs the same breakpoint (12px mobile / 20px desktop)

Desktop output is unchanged: `sm:-my-2` ≡ `-my-2` and `sm:h-5` ≡ `h-[20px]` at ≥ sm.

## Tests

Both written failing first and confirmed to catch the bug:

- `ChargeItem.spec.ts` — two cases asserting the margin and padding share a breakpoint, and that the spacer is responsive.
- `responsive.mobile.spec.ts` **RM-10** — measures each row against its timeline column via `getBoundingClientRect`. With the fix reverted it fails with `Received: 8`, the exact overflow.

## Verification

| Check | Result |
|---|---|
| `type-check` | clean |
| `lint` | 0 errors, 50 warnings (repo baseline) |
| `test:unit --run` | 716/716 |
| `build` | green |
| E2E `responsive.mobile` (mobile-chrome) | 10/10 |
| E2E `charges-list` (chromium) | 9/9 |

Also verified in-browser at 393×851 and 1280×900, light and dark: column overflow is 0.0px everywhere, the icon top aligns to the title top at both widths, and a pixel scan shows a uniform 229 (light) / `(74,84,100)` (dark) across row boundaries — no band.
