### PR TITLE
feat(frontend): share theme and locale with the website via domain cookies

### DIFF
--- a/e2e/i18n-theme.spec.ts
+++ b/e2e/i18n-theme.spec.ts
@@ -4,14 +4,14 @@
  * IT-01  Locale switch updates in-page UI labels
  * IT-02  Locale persists after page reload (cshtrkl cookie)
  * IT-03  Switching locale calls PUT /api/profile/locale (updateLocale)
- * IT-04  Theme menu: selecting Light/Dark pins html.dark and persists after reload (localStorage)
+ * IT-04  Theme menu: selecting Light/Dark pins html.dark and persists after reload (cshtrkt cookie)
  * IT-05  Document titles for each route (static meta.title; namedTitle is dead code — see NAV-09)
- * IT-06  Theme menu: selecting System follows prefers-color-scheme live and persists 'auto'
+ * IT-06  Theme menu: selecting System follows prefers-color-scheme live and persists 'system'
  *
  * Notes:
  * - NEVER click Sign Out (kills shared session).
  * - PUT /api/profile/locale is INTERCEPTED and not allowed to persist server-side.
- * - Client-only effects (html.dark class, cshtrkl cookie) are per-context and safe.
+ * - Client-only effects (html.dark class, cshtrkl/cshtrkt cookies) are per-context and safe.
  * - Locale is RESTORED at test end so subsequent tests start clean.
  * - The updateLocale path is PUT /api/profile/locale (src/api/profile.ts, updateLocale()).
  * - The app detects locale from cshtrkl cookie on mount, then overrides it from
@@ -24,6 +24,9 @@
  * - In System mode the trigger renders a composite icon (resolved sun/moon + a small
  *   monitor corner badge) — 2 <svg> nodes inside the trigger vs 1 for a manual pin.
  *   IT-06 asserts this count as a cheap, stable proxy for "the badge is showing."
+ * - Theme persists in the `cshtrkt` cookie, not localStorage (src/shared/themeCookie.ts).
+ *   VueUse's 'auto' maps to the cookie's 'system' — use `toCookieValue()`, imported from
+ *   themeCookieVocabulary.ts so this file's isolated tsconfig doesn't need env.ts's types.
  */
 import { test, expect } from '@playwright/test'
 import {
@@ -33,6 +36,7 @@ import {
     deleteWalletViaApi,
     assertNoErrorLeak,
 } from './support'
+import { toCookieValue } from '../src/shared/themeCookieVocabulary'
 
 // ── Helper: detect the current app locale ────────────────────────────────────
 // We read the *store* locale via the language menu's disabled item, NOT html.lang.
@@ -74,7 +78,7 @@ async function switchLocale(
     // first time on a page does an `await import('./messages/uk')` (lang/index.ts:63) before
     // setI18nLanguage flips html.lang — Vite transforms that chunk on first request, so under
     // cold start + parallel-worker load it can take several seconds. 10s gives that margin;
-    // the PUT this test asserts already fired synchronously from AppHeader's watch(locale).
+    // the PUT this test asserts already fired synchronously from AppHeader's onLocaleChange().
     await expect
         .poll(() => page.evaluate(() => document.documentElement.lang), { timeout: 10000 })
         .toBe(targetLocale)
@@ -96,6 +100,12 @@ async function gotoReady(page: Parameters<typeof shell.hamburger>[0], path: stri
     )
     await page.goto(path)
     await profileLoaded
+}
+
+// ── Helper: read the cshtrkt cookie value ────────────────────────────────────
+async function themeCookieValue(page: Parameters<typeof shell.hamburger>[0]): Promise<string | undefined> {
+    const cookies = await page.context().cookies()
+    return cookies.find(c => c.name === 'cshtrkt')?.value
 }
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -209,8 +219,8 @@ test.describe('S22 — i18n, dark mode, document titles', () => {
         'IT-03 switching locale fires PUT /api/profile/locale (updateLocale)',
         async ({ page }) => {
             // This test specifically asserts that the API call fires (IT-03 requirement).
-            // AppHeader.vue watch(locale) calls updateLocale(newLocale) when isLogged.
-            // The path is PUT /api/profile/locale (src/api/profile.ts line 84).
+            // onLocaleChange() calls updateLocale() when isLogged — only for a real user pick,
+            // not profile-load or cross-tab sync. Path: PUT /api/profile/locale.
             let updateLocaleFired = false
             let capturedLocale: string | null = null
 
@@ -268,8 +278,8 @@ test.describe('S22 — i18n, dark mode, document titles', () => {
                 )
                 .toBe(!isInitiallyDark)
 
-            // Reload → localStorage restores the pinned mode (VueUse colorMode). Poll: the
-            // html.dark class is reapplied on mount, which can land just after domcontentloaded.
+            // Reload → cshtrkt cookie restores the pinned mode; poll since html.dark
+            // reapplies just after domcontentloaded.
             await page.reload()
             await page.waitForLoadState('domcontentloaded')
             await expect
@@ -278,12 +288,10 @@ test.describe('S22 — i18n, dark mode, document titles', () => {
                     { timeout: 5000 },
                 )
                 .toBe(!isInitiallyDark)
+            // 'light'/'dark' pass through the cookie translation unchanged.
             await expect
-                .poll(
-                    () => page.evaluate(() => localStorage.getItem('vueuse-color-scheme')),
-                    { timeout: 5000 },
-                )
-                .toBe(targetChoice)
+                .poll(() => themeCookieValue(page), { timeout: 5000 })
+                .toBe(toCookieValue(targetChoice))
 
             // Restore original mode (per-context so harmless, but good practice)
             const restoreChoice: 'light' | 'dark' = isInitiallyDark ? 'dark' : 'light'
@@ -346,7 +354,7 @@ test.describe('S22 — i18n, dark mode, document titles', () => {
 
     // IT-06 ───────────────────────────────────────────────────────────────────
     test(
-        'IT-06 theme menu: selecting System follows prefers-color-scheme live and persists auto',
+        'IT-06 theme menu: selecting System follows prefers-color-scheme live and persists system',
         async ({ page }) => {
             // Pin the OS-level scheme so the assertions below are deterministic.
             await page.emulateMedia({ colorScheme: 'light' })
@@ -355,13 +363,10 @@ test.describe('S22 — i18n, dark mode, document titles', () => {
             await shell.darkModeToggle(page).click()
             await shell.themeMenuItem(page, 'system').click()
 
-            // Selecting System writes 'auto' to the VueUse colorMode storage key…
+            // VueUse's 'auto' translates to 'system' before writing cshtrkt.
             await expect
-                .poll(
-                    () => page.evaluate(() => localStorage.getItem('vueuse-color-scheme')),
-                    { timeout: 5000 },
-                )
-                .toBe('auto')
+                .poll(() => themeCookieValue(page), { timeout: 5000 })
+                .toBe(toCookieValue('auto'))
             // …and immediately follows the (emulated) device scheme.
             await expect
                 .poll(
@@ -402,11 +407,8 @@ test.describe('S22 — i18n, dark mode, document titles', () => {
             await shell.darkModeToggle(page).click()
             await shell.themeMenuItem(page, 'light').click()
             await expect
-                .poll(
-                    () => page.evaluate(() => localStorage.getItem('vueuse-color-scheme')),
-                    { timeout: 5000 },
-                )
-                .toBe('light')
+                .poll(() => themeCookieValue(page), { timeout: 5000 })
+                .toBe(toCookieValue('light'))
 
             // Manual pin: back down to a single icon/svg node — no monitor badge.
             await expect

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -251,8 +251,11 @@ test.describe('S1 — Navigation & App Shell', () => {
             // (localeChange() writes it via writeLocaleCookie())
             const updatedHtmlLang = await page.evaluate(() => document.documentElement.lang)
             expect(updatedHtmlLang).toBe(targetLocale)
+            const cookiesAfterSwitch = await page.context().cookies()
+            const localeCookieAfterSwitch = cookiesAfterSwitch.find(c => c.name === 'cshtrkl')
+            expect(localeCookieAfterSwitch?.value).toBe(targetLocale)
 
-            // The watch(locale) in AppHeader.vue calls updateLocale() when logged in
+            // onLocaleChange() in AppHeader.vue calls updateLocale() for this real, user-driven pick
             expect(updateLocaleFired).toBe(true)
 
             // ── Restore original locale ──────────────────────────────────────

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -10,7 +10,9 @@ import { useAuthStore } from '@/stores/auth'
 import { useProfileStore } from '@/stores/profile'
 import { updateLocale } from '@/api/profile'
 import { webSiteLink } from '@/shared/links'
-import { locales, loadLocaleAsync, type LocaleInterface } from '@/lang'
+import { COOKIE_NAME as THEME_COOKIE_NAME, themeCookieStorage } from '@/shared/themeCookie'
+import { useCrossTabSync } from '@/composables/useCrossTabSync'
+import { locales, type LocaleInterface } from '@/lang'
 import LogoFull from '@/components/LogoFull.vue'
 import HamburgerMenu from '@/components/Shared/HamburgerMenu.vue'
 
@@ -22,7 +24,13 @@ const authStore = useAuthStore()
 const { isLogged } = storeToRefs(authStore)
 const profileStore = useProfileStore()
 const { profile } = storeToRefs(profileStore)
-const mode = useColorMode()
+// Shared with the website via the `cshtrkt` cookie instead of localStorage (see shared/themeCookie.ts).
+const mode = useColorMode({ storageKey: THEME_COOKIE_NAME, storage: themeCookieStorage })
+
+// Re-applies cshtrkt/cshtrkl on focus/visibility if another tab changed them —
+// see composables/useCrossTabSync.ts for why this can't rely on VueUse's normal
+// cross-tab storage-event wiring.
+useCrossTabSync(mode)
 
 const isHeaderOpened = ref(false)
 
@@ -54,6 +62,12 @@ const currentLocale = computed(() => {
 
 function onLocaleChange(changed: LocaleInterface) {
     localeStore.localeChange(changed.code)
+
+    // Only a real user pick echoes to the server; profile load and cross-tab sync use
+    // other entry points and must not PUT the value straight back.
+    if (isLogged.value) {
+        updateLocale(changed.code).catch(() => {})
+    }
 }
 
 type ThemeChoice = 'light' | 'dark' | 'auto'
@@ -66,10 +80,8 @@ const themeChoices: { value: ThemeChoice; labelKey: string; icon: string }[] = [
 
 const isSystemTheme = computed(() => mode.store.value === 'auto')
 
-// mode.value resolves 'auto' down to the live device scheme (light/dark) and is reactive
-// to prefers-color-scheme changes; for manual light/dark it's the same as mode.store.value.
-// Drives the trigger's main glyph — the monitor badge (below, in the template) marks the
-// auto/system case on top of it.
+// mode.value resolves 'auto' to the live device scheme; the monitor badge in the template
+// marks the auto case on top of this glyph.
 const resolvedThemeIcon = computed(() => (mode.value === 'dark' ? 'i-lucide-moon' : 'i-lucide-sun'))
 
 const themeMenuItems = computed<DropdownMenuItem[][]>(() => {
@@ -92,14 +104,6 @@ const themeMenuItems = computed<DropdownMenuItem[][]>(() => {
 function onThemeChange(choice: ThemeChoice) {
     mode.value = choice
 }
-
-watch(locale, (newLocale) => {
-    loadLocaleAsync(newLocale)
-
-    if (isLogged.value) {
-        updateLocale(newLocale).catch(() => {})
-    }
-})
 
 watch(() => route.fullPath, () => {
     isHeaderOpened.value = false

--- a/src/components/__tests__/AppHeader.spec.ts
+++ b/src/components/__tests__/AppHeader.spec.ts
@@ -3,6 +3,9 @@ import { ref, computed, reactive, nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import AppHeader from '../AppHeader.vue'
+import { useAuthStore } from '@/stores/auth'
+import { useLocaleStore } from '@/stores/locale'
+import { updateLocale } from '@/api/profile'
 
 vi.mock('vue-i18n', () => ({
     useI18n: () => ({
@@ -63,8 +66,8 @@ vi.mock('@/shared/links', () => ({
 vi.mock('@/lang', () => ({
     locales: [
         { code: 'en', name: 'English', flag: '🇺🇸' },
+        { code: 'uk', name: 'Ukrainian', flag: '🇺🇦' },
     ],
-    loadLocaleAsync: vi.fn(),
 }))
 
 vi.mock('@/api/auth', () => ({
@@ -263,5 +266,35 @@ describe('AppHeader', () => {
         const wrapper = mountHeader()
         const btn = wrapper.find('[aria-label="language"]')
         expect(btn.exists()).toBe(true)
+    })
+
+    it('picking a locale from the menu fires updateLocale when logged in', async () => {
+        vi.mocked(updateLocale).mockClear()
+        const wrapper = mountHeader()
+        useAuthStore().isLogged = true
+        const vm = wrapper.vm as unknown as {
+            availableLocales: { label: string; onSelect?: () => void }[][]
+        }
+
+        // Goes through the real onSelect callback (onLocaleChange), not the store action
+        // directly — that's the only path that's supposed to echo to the server.
+        vm.availableLocales[0].find(i => i.label === 'Ukrainian')?.onSelect?.()
+        await nextTick()
+
+        expect(updateLocale).toHaveBeenCalledWith('uk')
+    })
+
+    it('a profile-load-triggered locale change does not fire updateLocale even when logged in', async () => {
+        vi.mocked(updateLocale).mockClear()
+        mountHeader()
+        useAuthStore().isLogged = true
+
+        // stores/profile.ts's setProfile() calls localeStore.localeChange(user.locale)
+        // directly (bypassing onLocaleChange) after login — must not echo the server's
+        // own value back to it.
+        useLocaleStore().localeChange('uk')
+        await nextTick()
+
+        expect(updateLocale).not.toHaveBeenCalled()
     })
 })

--- a/src/composables/__tests__/useCrossTabSync.spec.ts
+++ b/src/composables/__tests__/useCrossTabSync.spec.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { useCrossTabSync } from '../useCrossTabSync'
+import { useLocaleStore, LOCALE_COOKIE } from '@/stores/locale'
+
+type Mode = Parameters<typeof useCrossTabSync>[0]
+
+const THEME_COOKIE = 'cshtrkt'
+
+let cookieJar: Record<string, string>
+
+// See shared/__tests__/themeCookie.spec.ts for why jsdom's cookie jar is replaced.
+function installCookieJar() {
+    cookieJar = {}
+    Object.defineProperty(document, 'cookie', {
+        configurable: true,
+        get() {
+            return Object.entries(cookieJar)
+                .map(([name, value]) => `${name}=${value}`)
+                .join('; ')
+        },
+        set(raw: string) {
+            const firstPair = raw.split(';')[0]
+            const eqIndex = firstPair.indexOf('=')
+            const name = firstPair.slice(0, eqIndex).trim()
+            const value = firstPair.slice(eqIndex + 1)
+            if (/max-age=0(?:;|$)/.test(raw)) {
+                delete cookieJar[name]
+            } else {
+                cookieJar[name] = value
+            }
+        },
+    })
+}
+
+function setVisibility(state: 'visible' | 'hidden') {
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: state })
+}
+
+function makeMode(initial: 'light' | 'dark' | 'auto' = 'light'): Mode {
+    return { value: initial, store: { value: initial } } as Mode
+}
+
+function mountSync(mode: Mode) {
+    return mount(defineComponent({
+        setup() {
+            useCrossTabSync(mode)
+            return () => h('div')
+        },
+    }))
+}
+
+describe('useCrossTabSync', () => {
+    let wrapper: VueWrapper | undefined
+
+    beforeEach(() => {
+        installCookieJar()
+        setActivePinia(createPinia())
+        setVisibility('visible')
+    })
+
+    afterEach(() => {
+        wrapper?.unmount()
+        wrapper = undefined
+    })
+
+    it('applies a locale another tab wrote, on visibilitychange while visible', () => {
+        const store = useLocaleStore()
+        store.localeChange('en')
+        document.cookie = `${LOCALE_COOKIE}=uk`
+
+        wrapper = mountSync(makeMode())
+        document.dispatchEvent(new Event('visibilitychange'))
+
+        expect(store.locale).toBe('uk')
+    })
+
+    it('does not apply on visibilitychange while hidden', () => {
+        const store = useLocaleStore()
+        store.localeChange('en')
+        document.cookie = `${LOCALE_COOKIE}=uk`
+
+        wrapper = mountSync(makeMode())
+        setVisibility('hidden')
+        document.dispatchEvent(new Event('visibilitychange'))
+
+        expect(store.locale).toBe('en')
+    })
+
+    it('applies a locale another tab wrote, on window focus', () => {
+        const store = useLocaleStore()
+        store.localeChange('en')
+        document.cookie = `${LOCALE_COOKIE}=uk`
+
+        wrapper = mountSync(makeMode())
+        window.dispatchEvent(new Event('focus'))
+
+        expect(store.locale).toBe('uk')
+    })
+
+    it('ignores an unsupported locale cookie value', () => {
+        const store = useLocaleStore()
+        store.localeChange('en')
+        document.cookie = `${LOCALE_COOKIE}=fr`
+
+        wrapper = mountSync(makeMode())
+        document.dispatchEvent(new Event('visibilitychange'))
+
+        expect(store.locale).toBe('en')
+    })
+
+    it('does not rewrite the locale cookie when applying an external change', () => {
+        const store = useLocaleStore()
+        store.localeChange('en')
+        document.cookie = `${LOCALE_COOKIE}=uk`
+
+        wrapper = mountSync(makeMode())
+        document.dispatchEvent(new Event('visibilitychange'))
+
+        // Still exactly what the "other tab" wrote — applyExternalLocale never re-serializes it.
+        expect(cookieJar[LOCALE_COOKIE]).toBe('uk')
+    })
+
+    it('applies a theme another tab wrote', () => {
+        document.cookie = `${THEME_COOKIE}=dark`
+        const mode = makeMode('light')
+
+        wrapper = mountSync(mode)
+        document.dispatchEvent(new Event('visibilitychange'))
+
+        expect(mode.value).toBe('dark')
+    })
+
+    it('translates the "system" cookie value to "auto" when applying theme', () => {
+        document.cookie = `${THEME_COOKIE}=system`
+        const mode = makeMode('light')
+
+        wrapper = mountSync(mode)
+        document.dispatchEvent(new Event('visibilitychange'))
+
+        expect(mode.value).toBe('auto')
+    })
+
+    it('ignores a garbage theme cookie value', () => {
+        document.cookie = `${THEME_COOKIE}=banana`
+        const mode = makeMode('light')
+
+        wrapper = mountSync(mode)
+        document.dispatchEvent(new Event('visibilitychange'))
+
+        expect(mode.value).toBe('light')
+    })
+
+    it('does not touch theme when the cookie already matches the current mode', () => {
+        document.cookie = `${THEME_COOKIE}=light`
+        let sets = 0
+        const store = { value: 'light' as 'light' | 'dark' | 'auto' }
+        const mode = {
+            get value() { return store.value },
+            set value(v: 'light' | 'dark' | 'auto') { sets++; store.value = v },
+            store,
+        } as Mode
+
+        wrapper = mountSync(mode)
+        document.dispatchEvent(new Event('visibilitychange'))
+
+        expect(sets).toBe(0)
+    })
+
+    it('stops reacting after unmount', () => {
+        const store = useLocaleStore()
+        store.localeChange('en')
+
+        wrapper = mountSync(makeMode())
+        wrapper.unmount()
+        wrapper = undefined
+
+        document.cookie = `${LOCALE_COOKIE}=uk`
+        document.dispatchEvent(new Event('visibilitychange'))
+
+        expect(store.locale).toBe('en')
+    })
+})

--- a/src/composables/useCrossTabSync.ts
+++ b/src/composables/useCrossTabSync.ts
@@ -1,0 +1,52 @@
+import { onMounted, onUnmounted } from 'vue'
+import type { useColorMode } from '@vueuse/core'
+import { useLocaleStore } from '@/stores/locale'
+import { readRawCookie } from '@/shared/sharedCookie'
+import { fromCookieValue } from '@/shared/themeCookieVocabulary'
+
+const THEME_COOKIE = 'cshtrkt'
+const LOCALE_COOKIE = 'cshtrkl'
+
+type ColorMode = ReturnType<typeof useColorMode>
+
+// VueUse only wires the native `storage` event for a real Storage, and both cookies are
+// backed by a custom StorageLike — so re-read them on focus/visibility instead.
+// Takes AppHeader's `mode` rather than calling useColorMode() again, which would be an
+// independent instance.
+export function useCrossTabSync(mode: ColorMode) {
+    const localeStore = useLocaleStore()
+
+    function sync() {
+        const cookieLocale = readRawCookie(LOCALE_COOKIE)
+        if ((cookieLocale === 'en' || cookieLocale === 'uk') && cookieLocale !== localeStore.locale) {
+            localeStore.applyExternalLocale(cookieLocale)
+        }
+
+        const cookieTheme = readRawCookie(THEME_COOKIE)
+        if (cookieTheme) {
+            const resolved = fromCookieValue(cookieTheme)
+            if (
+                (resolved === 'auto' || resolved === 'light' || resolved === 'dark')
+                && resolved !== mode.store.value
+            ) {
+                mode.value = resolved
+            }
+        }
+    }
+
+    function onVisibilityChange() {
+        if (document.visibilityState === 'visible') {
+            sync()
+        }
+    }
+
+    onMounted(() => {
+        document.addEventListener('visibilitychange', onVisibilityChange)
+        window.addEventListener('focus', sync)
+    })
+
+    onUnmounted(() => {
+        document.removeEventListener('visibilitychange', onVisibilityChange)
+        window.removeEventListener('focus', sync)
+    })
+}

--- a/src/shared/__tests__/sharedCookie.spec.ts
+++ b/src/shared/__tests__/sharedCookie.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { parentDomain, readRawCookie, writeRawCookie, deleteRawCookie } from '../sharedCookie'
+
+let cookieJar: Record<string, string>
+let writes: string[]
+
+// See themeCookie.spec.ts for why jsdom's cookie jar is replaced.
+function installCookieJar() {
+    cookieJar = {}
+    writes = []
+    Object.defineProperty(document, 'cookie', {
+        configurable: true,
+        get() {
+            return Object.entries(cookieJar)
+                .map(([name, value]) => `${name}=${value}`)
+                .join('; ')
+        },
+        set(raw: string) {
+            writes.push(raw)
+            const firstPair = raw.split(';')[0]
+            const eqIndex = firstPair.indexOf('=')
+            const name = firstPair.slice(0, eqIndex).trim()
+            const value = firstPair.slice(eqIndex + 1)
+            if (/max-age=0(?:;|$)/.test(raw)) {
+                delete cookieJar[name]
+            } else {
+                cookieJar[name] = value
+            }
+        },
+    })
+}
+
+beforeEach(() => {
+    installCookieJar()
+})
+
+afterEach(() => {
+    delete window.__APP_CONFIG__
+})
+
+describe('parentDomain', () => {
+    it('derives the hostname from VITE_WEBSITE_URL', () => {
+        window.__APP_CONFIG__ = { VITE_WEBSITE_URL: 'https://cash-track.app' }
+
+        expect(parentDomain()).toBe('cash-track.app')
+    })
+
+    it('returns null when VITE_WEBSITE_URL is unparseable', () => {
+        window.__APP_CONFIG__ = { VITE_WEBSITE_URL: 'not-a-valid-url' }
+
+        expect(parentDomain()).toBeNull()
+    })
+})
+
+describe('readRawCookie / writeRawCookie / deleteRawCookie', () => {
+    it('writes and reads a cookie by name', () => {
+        writeRawCookie('foo', 'bar')
+
+        expect(readRawCookie('foo')).toBe('bar')
+    })
+
+    it('returns null for a cookie that does not exist', () => {
+        expect(readRawCookie('missing')).toBeNull()
+    })
+
+    it('scopes the cookie to the parent domain when VITE_WEBSITE_URL is set', () => {
+        window.__APP_CONFIG__ = { VITE_WEBSITE_URL: 'https://cash-track.app' }
+
+        writeRawCookie('foo', 'bar')
+
+        expect(writes.at(-1)).toContain('Domain=.cash-track.app')
+    })
+
+    it.each(['localhost', '127.0.0.1'])('falls back to a host-only cookie for %s', (host) => {
+        window.__APP_CONFIG__ = { VITE_WEBSITE_URL: `http://${host}:3001` }
+
+        writeRawCookie('foo', 'bar')
+
+        expect(writes.at(-1)).not.toContain('Domain=')
+    })
+
+    it('deletes a host-only sibling before writing the domain-scoped cookie', () => {
+        window.__APP_CONFIG__ = { VITE_WEBSITE_URL: 'https://cash-track.app' }
+
+        writeRawCookie('foo', 'bar')
+
+        expect(writes[0]).toContain('max-age=0')
+        expect(writes[1]).toContain('Domain=.cash-track.app')
+    })
+
+    it('removes a cookie', () => {
+        document.cookie = 'foo=bar'
+
+        deleteRawCookie('foo')
+
+        expect(cookieJar.foo).toBeUndefined()
+    })
+})

--- a/src/shared/__tests__/themeCookie.spec.ts
+++ b/src/shared/__tests__/themeCookie.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { themeCookieStorage, COOKIE_NAME } from '../themeCookie'
+
+const LEGACY_KEY = 'vueuse-color-scheme'
+
+let cookieJar: Record<string, string>
+let writes: string[]
+
+// jsdom's cookie jar enforces Domain/Path against the test origin and would silently drop
+// the domain-scoped cookies this module writes. This jar records every write (so the
+// attribute string can be asserted) and reflects name=value pairs back through the getter.
+function installCookieJar() {
+    cookieJar = {}
+    writes = []
+    Object.defineProperty(document, 'cookie', {
+        configurable: true,
+        get() {
+            return Object.entries(cookieJar)
+                .map(([name, value]) => `${name}=${value}`)
+                .join('; ')
+        },
+        set(raw: string) {
+            writes.push(raw)
+            const firstPair = raw.split(';')[0]
+            const eqIndex = firstPair.indexOf('=')
+            const name = firstPair.slice(0, eqIndex).trim()
+            const value = firstPair.slice(eqIndex + 1)
+            if (/max-age=0(?:;|$)/.test(raw)) {
+                delete cookieJar[name]
+            } else {
+                cookieJar[name] = value
+            }
+        },
+    })
+}
+
+beforeEach(() => {
+    installCookieJar()
+    window.localStorage.clear()
+})
+
+afterEach(() => {
+    delete window.__APP_CONFIG__
+})
+
+describe('themeCookieStorage', () => {
+    it('translates cookie value "system" to vueuse "auto" on read', () => {
+        document.cookie = `${COOKIE_NAME}=system`
+
+        expect(themeCookieStorage.getItem(COOKIE_NAME)).toBe('auto')
+    })
+
+    it('translates vueuse "auto" to cookie value "system" on write', () => {
+        themeCookieStorage.setItem(COOKIE_NAME, 'auto')
+
+        expect(cookieJar[COOKIE_NAME]).toBe('system')
+    })
+
+    it.each(['light', 'dark'])('passes "%s" through unchanged on read', (value) => {
+        document.cookie = `${COOKIE_NAME}=${value}`
+
+        expect(themeCookieStorage.getItem(COOKIE_NAME)).toBe(value)
+    })
+
+    it.each(['light', 'dark'])('passes "%s" through unchanged on write', (value) => {
+        themeCookieStorage.setItem(COOKIE_NAME, value)
+
+        expect(cookieJar[COOKIE_NAME]).toBe(value)
+    })
+
+    it('derives the cookie Domain from VITE_WEBSITE_URL', () => {
+        window.__APP_CONFIG__ = { VITE_WEBSITE_URL: 'https://cash-track.app' }
+
+        themeCookieStorage.setItem(COOKIE_NAME, 'dark')
+
+        expect(writes.at(-1)).toContain('Domain=.cash-track.app')
+    })
+
+    it('falls back to a host-only cookie (no Domain attribute) when VITE_WEBSITE_URL is unparseable', () => {
+        window.__APP_CONFIG__ = { VITE_WEBSITE_URL: 'not-a-valid-url' }
+
+        themeCookieStorage.setItem(COOKIE_NAME, 'dark')
+
+        expect(writes.at(-1)).not.toContain('Domain=')
+    })
+
+    it('seeds the cookie from the legacy localStorage key when the cookie is absent', () => {
+        window.localStorage.setItem(LEGACY_KEY, 'dark')
+
+        expect(themeCookieStorage.getItem(COOKIE_NAME)).toBe('dark')
+        expect(cookieJar[COOKIE_NAME]).toBe('dark')
+    })
+
+    it('translates a legacy "auto" localStorage value into a "system" cookie during migration', () => {
+        window.localStorage.setItem(LEGACY_KEY, 'auto')
+
+        expect(themeCookieStorage.getItem(COOKIE_NAME)).toBe('auto')
+        expect(cookieJar[COOKIE_NAME]).toBe('system')
+    })
+
+    it('ignores the legacy localStorage key once the shared cookie already exists', () => {
+        document.cookie = `${COOKIE_NAME}=light`
+        window.localStorage.setItem(LEGACY_KEY, 'dark')
+
+        expect(themeCookieStorage.getItem(COOKIE_NAME)).toBe('light')
+    })
+
+    it('returns null when neither the cookie nor the legacy key exist', () => {
+        expect(themeCookieStorage.getItem(COOKIE_NAME)).toBeNull()
+    })
+
+    it('removes the cookie', () => {
+        document.cookie = `${COOKIE_NAME}=dark`
+
+        themeCookieStorage.removeItem(COOKIE_NAME)
+
+        expect(cookieJar[COOKIE_NAME]).toBeUndefined()
+    })
+})

--- a/src/shared/sharedCookie.ts
+++ b/src/shared/sharedCookie.ts
@@ -1,0 +1,56 @@
+import { getEnv } from './env'
+
+// Shared by the cshtrkt (theme) and cshtrkl (locale) cookies — both live 1 year.
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 365
+
+export function parentDomain(): string | null {
+    const websiteUrl = getEnv('VITE_WEBSITE_URL')
+    if (!websiteUrl) {
+        return null
+    }
+
+    try {
+        return new URL(websiteUrl).hostname
+    } catch {
+        return null
+    }
+}
+
+export function readRawCookie(name: string): string | null {
+    const prefix = `${name}=`
+    const pair = document.cookie
+        .split(';')
+        .map((part) => part.trim())
+        .find((part) => part.startsWith(prefix))
+
+    return pair ? decodeURIComponent(pair.slice(prefix.length)) : null
+}
+
+export function deleteRawCookie(name: string) {
+    document.cookie = `${name}=; path=/; max-age=0`
+}
+
+// Always deletes a host-only sibling first — a domain-scoped and host-only
+// cookie of the same name can otherwise coexist, and reads become ambiguous.
+export function writeRawCookie(name: string, value: string) {
+    deleteRawCookie(name)
+
+    const domain = parentDomain()
+    const attrs = [
+        `${name}=${encodeURIComponent(value)}`,
+        'path=/',
+        `max-age=${COOKIE_MAX_AGE}`,
+        'SameSite=Lax',
+    ]
+
+    // localhost/IP can't take a leading-dot Domain — fall back to host-only.
+    if (domain && domain !== 'localhost' && !/^[\d.]+$/.test(domain)) {
+        attrs.push(`Domain=.${domain}`)
+    }
+
+    if (window.location.protocol === 'https:') {
+        attrs.push('Secure')
+    }
+
+    document.cookie = attrs.join('; ')
+}

--- a/src/shared/themeCookie.ts
+++ b/src/shared/themeCookie.ts
@@ -1,0 +1,35 @@
+import type { StorageLike } from '@vueuse/core'
+import { readRawCookie, writeRawCookie, deleteRawCookie } from './sharedCookie'
+import { fromCookieValue, toCookieValue } from './themeCookieVocabulary'
+
+// Shares the theme with the website via the domain-scoped `cshtrkt` cookie. VueUse stores
+// 'auto', the website expects 'system' — this adapter translates between them.
+
+const COOKIE_NAME = 'cshtrkt'
+const LEGACY_STORAGE_KEY = 'vueuse-color-scheme'
+
+export const themeCookieStorage: StorageLike = {
+    getItem(key) {
+        const raw = readRawCookie(key)
+        if (raw) {
+            return fromCookieValue(raw)
+        }
+
+        // One-time migration from the old VueUse localStorage key.
+        const legacy = window.localStorage.getItem(LEGACY_STORAGE_KEY)
+        if (legacy) {
+            writeRawCookie(key, toCookieValue(legacy))
+            return legacy
+        }
+
+        return null
+    },
+    setItem(key, value) {
+        writeRawCookie(key, toCookieValue(value))
+    },
+    removeItem(key) {
+        deleteRawCookie(key)
+    },
+}
+
+export { COOKIE_NAME, toCookieValue }

--- a/src/shared/themeCookieVocabulary.ts
+++ b/src/shared/themeCookieVocabulary.ts
@@ -1,0 +1,11 @@
+// Kept import-free so e2e/ can import this without dragging in env.ts's
+// ambient types (not visible under e2e/tsconfig.json's isolated program).
+
+// vueuse ('auto'|'light'|'dark') <-> cookie ('system'|'light'|'dark')
+export function fromCookieValue(raw: string): string {
+    return raw === 'system' ? 'auto' : raw
+}
+
+export function toCookieValue(value: string): string {
+    return value === 'auto' ? 'system' : value
+}

--- a/src/stores/__tests__/locale.spec.ts
+++ b/src/stores/__tests__/locale.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useLocaleStore, LOCALE_COOKIE } from '../locale'
+
+let cookieJar: Record<string, string>
+let writes: string[]
+
+// See shared/__tests__/themeCookie.spec.ts for why jsdom's cookie jar is replaced.
+function installCookieJar() {
+    cookieJar = {}
+    writes = []
+    Object.defineProperty(document, 'cookie', {
+        configurable: true,
+        get() {
+            return Object.entries(cookieJar)
+                .map(([name, value]) => `${name}=${value}`)
+                .join('; ')
+        },
+        set(raw: string) {
+            writes.push(raw)
+            const firstPair = raw.split(';')[0]
+            const eqIndex = firstPair.indexOf('=')
+            const name = firstPair.slice(0, eqIndex).trim()
+            const value = firstPair.slice(eqIndex + 1)
+            if (/max-age=0(?:;|$)/.test(raw)) {
+                delete cookieJar[name]
+            } else {
+                cookieJar[name] = value
+            }
+        },
+    })
+}
+
+beforeEach(() => {
+    installCookieJar()
+    setActivePinia(createPinia())
+})
+
+afterEach(() => {
+    delete window.__APP_CONFIG__
+})
+
+describe('useLocaleStore', () => {
+    it('localeChange writes the cshtrkl cookie', () => {
+        const store = useLocaleStore()
+
+        store.localeChange('uk')
+
+        expect(cookieJar[LOCALE_COOKIE]).toBe('uk')
+    })
+
+    it('scopes the cookie to the parent domain when VITE_WEBSITE_URL is set', () => {
+        window.__APP_CONFIG__ = { VITE_WEBSITE_URL: 'https://cash-track.app' }
+        const store = useLocaleStore()
+
+        store.localeChange('uk')
+
+        expect(writes.at(-1)).toContain('Domain=.cash-track.app')
+    })
+
+    it('falls back to a host-only cookie when VITE_WEBSITE_URL is unparseable', () => {
+        window.__APP_CONFIG__ = { VITE_WEBSITE_URL: 'not-a-valid-url' }
+        const store = useLocaleStore()
+
+        store.localeChange('uk')
+
+        expect(writes.at(-1)).not.toContain('Domain=')
+    })
+
+    it('uses SameSite=Lax', () => {
+        const store = useLocaleStore()
+
+        store.localeChange('uk')
+
+        expect(writes.at(-1)).toContain('SameSite=Lax')
+    })
+
+    it('deletes a host-only sibling before writing (single-cookie invariant)', () => {
+        window.__APP_CONFIG__ = { VITE_WEBSITE_URL: 'https://cash-track.app' }
+        const store = useLocaleStore()
+
+        store.localeChange('uk')
+
+        expect(writes[0]).toContain('max-age=0')
+        expect(writes[1]).toContain('Domain=.cash-track.app')
+    })
+
+    it('loadCachedLocale reads a supported locale from the cookie', () => {
+        document.cookie = `${LOCALE_COOKIE}=uk`
+        const store = useLocaleStore()
+
+        store.loadCachedLocale()
+
+        expect(store.locale).toBe('uk')
+    })
+
+    it('loadCachedLocale falls back to the default locale when the cookie is absent', () => {
+        const store = useLocaleStore()
+
+        store.loadCachedLocale()
+
+        expect(store.locale).toBe('en')
+        expect(cookieJar[LOCALE_COOKIE]).toBe('en')
+    })
+
+    it('loadCachedLocale ignores an unsupported cookie value', () => {
+        document.cookie = `${LOCALE_COOKIE}=fr`
+        const store = useLocaleStore()
+
+        store.loadCachedLocale()
+
+        expect(store.locale).toBe('en')
+    })
+
+    it('applyExternalLocale sets the locale without writing the cookie', () => {
+        const store = useLocaleStore()
+        store.localeChange('en')
+        writes.length = 0
+
+        store.applyExternalLocale('uk')
+
+        expect(store.locale).toBe('uk')
+        expect(writes).toHaveLength(0)
+    })
+})

--- a/src/stores/locale.ts
+++ b/src/stores/locale.ts
@@ -1,22 +1,17 @@
 import { shallowRef, watch } from 'vue'
 import { defineStore } from 'pinia'
 import { loadLocaleAsync } from '@/lang'
+import { readRawCookie, writeRawCookie } from '@/shared/sharedCookie'
 
-const LOCALE_COOKIE = 'cshtrkl'
-const COOKIE_MAX_AGE = 365 * 24 * 60 * 60 // 365 days in seconds
+// Domain-scoped (see shared/sharedCookie.ts) so the marketing website sees it too.
+export const LOCALE_COOKIE = 'cshtrkl'
 
 function readLocaleCookie(): string | null {
-    const match = document.cookie.match(/(?:^|;\s*)cshtrkl=([^;]*)/)
-    return match ? decodeURIComponent(match[1]) : null
+    return readRawCookie(LOCALE_COOKIE)
 }
 
 function writeLocaleCookie(locale: string) {
-    document.cookie = [
-        `${LOCALE_COOKIE}=${encodeURIComponent(locale)}`,
-        'path=/',
-        `max-age=${COOKIE_MAX_AGE}`,
-        'SameSite=Strict',
-    ].join('; ')
+    writeRawCookie(LOCALE_COOKIE, locale)
 }
 
 export const useLocaleStore = defineStore('locale', () => {
@@ -37,7 +32,13 @@ export const useLocaleStore = defineStore('locale', () => {
         }
     }
 
-    return { locale, localeChange, loadCachedLocale }
+    // Applies a locale another tab already wrote to the cookie (see useCrossTabSync).
+    // Distinct from localeChange only in that it skips the write-back — it's already correct.
+    function applyExternalLocale(newLocale: 'en' | 'uk') {
+        locale.value = newLocale
+    }
+
+    return { locale, localeChange, loadCachedLocale, applyExternalLocale }
 })
 
 export function syncLocaleWithI18n() {


### PR DESCRIPTION
Closes #107. Paired with cash-track/website#90.

## Problem statement

Theme and language were stored per-origin. The SPA is on `my.cash-track.app` and the marketing site on `cash-track.app`, so a preference set in one was invisible to the other: switching to Ukrainian or to dark mode in the app did not carry over to the website, or back.

## Changes

Both preferences now live in parent-domain cookies — `cshtrkt` for theme, `cshtrkl` for locale — read and written through a shared helper that derives the parent from `VITE_WEBSITE_URL` and falls back to a host-only cookie for `localhost` and bare IPs. Existing `vueuse-color-scheme` values migrate across on first read.

VueUse stores `auto` where the website's color-mode stores `system`, so a small vocabulary module translates between the two. It is deliberately import-free: `e2e/tsconfig.json` sets `include: ["**/*"]`, which overrides the app tsconfig's include, so ambient types are not in the Playwright program and a leaf module is the only shape usable from both.

Moving off `localStorage` costs VueUse's cross-tab sync, which only attaches the native `storage` listener when the backing store is a real `Storage`; a custom `StorageLike` silently downgrades to an in-page event. `useCrossTabSync` restores it by re-reading both cookies on `focus` and `visibilitychange`.

Every write deletes the host-only sibling first. A host-only and a domain-scoped cookie of the same name coexist and are both sent, and the website's pre-paint parser requires exactly one match — on a duplicate it falls back to `system` and writes that back over the real value.

The locale `PUT` moved from a watcher into the header's change handler. The watcher fired for every source of a locale change, including profile load, so signing in echoed the server's own value straight back to it. Only a genuine user pick should write.

## Verification

Reviewed across three rounds, with two substantive findings fixed: the echo-`PUT` above, and a dead `watch(locale)` in `AppHeader` that duplicated `syncLocaleWithI18n`.

- `type-check`, `lint`, and `build` all exit 0.
- 759 unit tests across 88 files pass, including new specs for the shared cookie helper, the theme adapter, the locale store, and `useCrossTabSync`. Those specs install a fake cookie jar because jsdom enforces Domain and Path against the test origin, which makes a real parent-domain cookie unwritable there.
- Full Playwright suite green: 195/195 (chromium 185, mobile-chrome 10), zero flaky.
- Browser-verified with `agent-browser` against the full local stack: exactly one `cshtrkt` and one `cshtrkl`, both `.dev-cash-track.app`, `Lax`, `Secure`; theme and locale round-trip across the origin hop and survive five hard reloads; console clean.
- No-echo invariant observed directly — a full reload issues only `GET /api/profile`, while a header locale pick issues `PUT /api/profile/locale`.