### PR TITLE
feat(frontend): cache the profile in a shared cookie to avoid header flash

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -12,15 +12,23 @@
  * NAV-09  Title guard: router.push with nameForTitle sets namedTitle
  * NAV-10  Unknown path /nope — no crash, app shell still present
  * NAV-11  Footer degrades gracefully when no release version/commit vars are configured
+ * NAV-12  Cached profile renders the header name before GET /api/profile resolves (#147)
+ * NAV-13  A 401 from the API drops the cshtrkp cache cookie (#147)
  */
 import { test, expect } from '@playwright/test'
 import {
     label,
     createWalletViaApi,
     deleteWalletViaApi,
+    routeDelay,
+    route401,
     shell,
     assertNoErrorLeak,
 } from './support'
+
+// A literal, not an import: this name is a wire contract shared with the separate website
+// repo, so a rename must fail here rather than be silently followed.
+const PROFILE_COOKIE = 'cshtrkp'
 
 // ── Local selector helpers not yet in support/selectors.ts ───────────────────
 //
@@ -36,6 +44,11 @@ const profileMenuTrigger = (page: Parameters<typeof shell.hamburger>[0]) =>
 // In AppHeader this is the second labeled button after the dark-mode toggle.
 const langMenuTrigger = (page: Parameters<typeof shell.hamburger>[0]) =>
     shell.languageToggle(page)
+
+// Context-level, so it survives the cross-origin redirect NAV-13 triggers.
+async function cookieNames(page: Parameters<typeof shell.hamburger>[0]): Promise<string[]> {
+    return (await page.context().cookies()).map(c => c.name)
+}
 // ─────────────────────────────────────────────────────────────────────────────
 
 test.describe('S1 — Navigation & App Shell', () => {
@@ -353,6 +366,54 @@ test.describe('S1 — Navigation & App Shell', () => {
             await expect(footer.locator('a[href*="github.com/cash-track/frontend"]')).toHaveCount(0)
 
             await assertNoErrorLeak(page)
+        },
+    )
+
+    // NAV-12 ──────────────────────────────────────────────────────────────────
+    test(
+        'NAV-12 cached profile renders the header name before GET /api/profile resolves',
+        async ({ page }) => {
+            // Warm the cache with one normal load, and remember the name it settled on.
+            await page.goto('/wallets')
+            const trigger = profileMenuTrigger(page)
+            await expect(trigger).not.toBeEmpty({ timeout: 15000 })
+            const displayName = ((await trigger.textContent()) ?? '').trim()
+            expect(displayName).not.toBe('')
+            await expect.poll(() => cookieNames(page), { timeout: 5000 }).toContain(PROFILE_COOKIE)
+
+            // Hold the profile GET open so the cookie is the only possible source for the
+            // name. Do not page.unroute() here — it races the in-flight handler.
+            const release = await routeDelay(page, '**/api/profile')
+            await page.reload({ waitUntil: 'domcontentloaded' })
+
+            // #147: the name is on screen while the request is still pending.
+            await expect(trigger).toContainText(displayName, { timeout: 10000 })
+
+            release()
+            await expect(trigger).toContainText(displayName)
+            await assertNoErrorLeak(page)
+        },
+    )
+
+    // NAV-13 ──────────────────────────────────────────────────────────────────
+    test(
+        'NAV-13 a 401 from the API drops the cached profile cookie',
+        async ({ page }) => {
+            // The 401 is faked by interception so the shared E2E session is never revoked —
+            // same reason NAV-06 never clicks Sign Out. Logout clearing is unit-tested in
+            // stores/__tests__/auth.spec.ts.
+            await page.goto('/wallets')
+            await expect(profileMenuTrigger(page)).not.toBeEmpty({ timeout: 15000 })
+            await expect.poll(() => cookieNames(page), { timeout: 5000 }).toContain(PROFILE_COOKIE)
+
+            await route401(page, '**/api/profile')
+            await page.reload({ waitUntil: 'domcontentloaded' })
+
+            await expect
+                .poll(() => cookieNames(page), { timeout: 10000 })
+                .not.toContain(PROFILE_COOKIE)
+
+            // No assertNoErrorLeak — this ends on the website login page, off the SPA.
         },
     )
 })

--- a/src/App.vue
+++ b/src/App.vue
@@ -32,6 +32,7 @@ localeStore.loadCachedLocale()
 syncLocaleWithI18n()
 
 const profileStore = useProfileStore()
+profileStore.loadCachedProfile()
 const authStore = useAuthStore()
 const { loading, failed, lastError } = storeToRefs(profileStore)
 const { isLogged } = storeToRefs(authStore)

--- a/src/__tests__/App.spec.ts
+++ b/src/__tests__/App.spec.ts
@@ -54,6 +54,7 @@ const mockIsLogged = shallowRef(false)
 const mockFailed = shallowRef(false)
 const mockLastError = shallowRef<unknown>(null)
 const mockLoadProfile = vi.fn()
+const mockLoadCachedProfile = vi.fn()
 
 vi.mock('@/stores/profile', () => ({
     useProfileStore: () => ({
@@ -61,6 +62,7 @@ vi.mock('@/stores/profile', () => ({
         failed: mockFailed,
         lastError: mockLastError,
         loadProfile: mockLoadProfile,
+        loadCachedProfile: mockLoadCachedProfile,
     }),
 }))
 
@@ -102,6 +104,7 @@ describe('App.vue', () => {
         setActivePinia(createPinia())
         hrefSpy.mockClear()
         mockLoadProfile.mockClear()
+        mockLoadCachedProfile.mockClear()
         mockLoading.value = true
         mockIsLogged.value = false
         mockFailed.value = false

--- a/src/api/__tests__/client.spec.ts
+++ b/src/api/__tests__/client.spec.ts
@@ -8,10 +8,49 @@ import {
     REQUEST_TIMEOUT_MS,
     RETRY_MAX_ATTEMPTS,
 } from '../client'
+import { PROFILE_COOKIE, writeCachedProfile } from '@/shared/profileCookie'
 
 vi.mock('@/shared/links', () => ({
     webSiteLink: (path: string) => `https://website.test${path}`,
 }))
+
+const mockCachedProfile = {
+    v: 1 as const,
+    id: 1,
+    name: 'Ann',
+    lastName: null,
+    nickName: 'ann',
+    email: 'a@b.c',
+    photoUrl: null,
+    isEmailConfirmed: true,
+    locale: 'en',
+}
+
+let cookieJar: Record<string, string>
+
+// See shared/__tests__/sharedCookie.spec.ts for why jsdom's native cookie jar is replaced.
+function installCookieJar() {
+    cookieJar = {}
+    Object.defineProperty(document, 'cookie', {
+        configurable: true,
+        get() {
+            return Object.entries(cookieJar)
+                .map(([name, value]) => `${name}=${value}`)
+                .join('; ')
+        },
+        set(raw: string) {
+            const firstPair = raw.split(';')[0]
+            const eqIndex = firstPair.indexOf('=')
+            const name = firstPair.slice(0, eqIndex).trim()
+            const value = firstPair.slice(eqIndex + 1)
+            if (/max-age=0(?:;|$)/.test(raw)) {
+                delete cookieJar[name]
+            } else {
+                cookieJar[name] = value
+            }
+        },
+    })
+}
 
 // Minimal AxiosInstance mock factory
 function mockInstance(overrides: Partial<AxiosInstance> = {}): AxiosInstance {
@@ -62,6 +101,7 @@ describe('apiCall', () => {
     let originalReload: () => void
 
     beforeEach(() => {
+        installCookieJar()
         originalHref = window.location.href
         originalReload = window.location.reload
         Object.defineProperty(window, 'location', {
@@ -115,6 +155,7 @@ describe('apiCall', () => {
     })
 
     it('redirects to login when CSRF refresh returns 401', async () => {
+        writeCachedProfile(mockCachedProfile)
         const fn = vi.fn().mockRejectedValue(new CsrfError(new Error('CSRF')))
 
         const csrfError = Object.assign(new AxiosError('Unauthorized'), {
@@ -126,9 +167,12 @@ describe('apiCall', () => {
 
         await expect(apiCall(fn, () => instance)).rejects.toThrow('redirecting to login')
         expect(window.location.href).toBe('https://website.test/login')
+        // Same "session is dead" case as a direct 401.
+        expect(document.cookie).not.toContain(PROFILE_COOKIE)
     })
 
     it('reloads page when CSRF refresh throws unexpected error', async () => {
+        writeCachedProfile(mockCachedProfile)
         const fn = vi.fn().mockRejectedValue(new CsrfError(new Error('CSRF')))
         const instance = mockInstance({
             get: vi.fn().mockRejectedValue(new Error('Redis down')),
@@ -136,6 +180,8 @@ describe('apiCall', () => {
 
         await expect(apiCall(fn, () => instance)).rejects.toThrow('Redis down')
         expect(window.location.reload).toHaveBeenCalled()
+        // An unexpected refresh error is not proof the session is dead.
+        expect(document.cookie).toContain(PROFILE_COOKIE)
     })
 
     it('does not apply CSRF retry to GET requests with an HTTP response error', async () => {
@@ -302,6 +348,74 @@ function instanceWithResponses(responses: Array<Partial<AxiosResponse>>): {
 
 const JSON_HEADERS = { 'content-type': 'application/json; charset=utf-8' }
 const PROFILE_BODY = '{"data":{"id":1,"name":"Jane"}}'
+
+describe('createAxiosInstance — 401 handling', () => {
+    let originalHref: string
+
+    beforeEach(() => {
+        installCookieJar()
+        originalHref = window.location.href
+        Object.defineProperty(window, 'location', {
+            writable: true,
+            value: { href: '' },
+        })
+    })
+
+    afterEach(() => {
+        Object.defineProperty(window, 'location', {
+            writable: true,
+            value: { href: originalHref },
+        })
+    })
+
+    it('clears the cshtrkp cookie and redirects to login on a 401 response', () => {
+        writeCachedProfile(mockCachedProfile)
+        expect(document.cookie).toContain(PROFILE_COOKIE)
+
+        // A custom adapter bypasses axios' settle logic, so a 401 would resolve rather than
+        // reject. Invoke the registered rejected handler directly instead.
+        const instance = createAxiosInstance()
+        const rejectedHandler = (
+            instance.interceptors.response as unknown as {
+                handlers: Array<{ rejected?: (error: unknown) => unknown }>
+            }
+        ).handlers[0]?.rejected
+        expect(rejectedHandler).toBeTypeOf('function')
+
+        const error = Object.assign(new AxiosError('Unauthorized'), {
+            response: { status: 401 } as AxiosResponse,
+        })
+        rejectedHandler?.(error)
+
+        expect(document.cookie).not.toContain(PROFILE_COOKIE)
+        expect(window.location.href).toBe('https://website.test/login')
+    })
+
+    // Only logout or a 401 clears the cookie — no other status may.
+    it.each([500, 503, 403, 429])(
+        'leaves the cshtrkp cookie intact and does not redirect on a %i response',
+        async (status) => {
+            writeCachedProfile(mockCachedProfile)
+            expect(document.cookie).toContain(PROFILE_COOKIE)
+
+            const instance = createAxiosInstance()
+            const rejectedHandler = (
+                instance.interceptors.response as unknown as {
+                    handlers: Array<{ rejected?: (error: unknown) => unknown }>
+                }
+            ).handlers[0]?.rejected
+            expect(rejectedHandler).toBeTypeOf('function')
+
+            const error = Object.assign(new AxiosError('Server error'), {
+                response: { status } as AxiosResponse,
+            })
+
+            await expect(Promise.resolve(rejectedHandler?.(error))).rejects.toBe(error)
+            expect(document.cookie).toContain(PROFILE_COOKIE)
+            expect(window.location.href).toBe('')
+        },
+    )
+})
 
 describe('malformed response detection', () => {
     it('rejects a 200 JSON response whose body never arrived', async () => {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosError, type AxiosInstance, type AxiosResponse } from 'axios'
 import { webSiteLink } from '@/shared/links'
 import { getEnv } from '@/shared/env'
+import { clearCachedProfile } from '@/shared/profileCookie'
 
 // Axios normalizes response header lookups to lowercase regardless of wire casing.
 const TRACE_ID_HEADER = 'x-ct-trace-id'
@@ -131,6 +132,8 @@ export function createAxiosInstance(): AxiosInstance {
         (error: unknown) => {
             if (error instanceof AxiosError && error.response) {
                 if (error.response.status === 401) {
+                    // Session is dead — drop the display cache so no stale logged-in header.
+                    clearCachedProfile()
                     window.location.href = webSiteLink('/login')
                     return new Promise(() => {}) // never resolves — navigation takes over
                 }
@@ -211,6 +214,7 @@ export async function apiCall<T>(
                 }
 
                 // Refresh returned false (401) — auth expired
+                clearCachedProfile()
                 window.location.href = webSiteLink('/login')
                 return Promise.reject(new Error('CSRF refresh failed — redirecting to login'))
             }

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -10,6 +10,7 @@ import { useAuthStore } from '@/stores/auth'
 import { useProfileStore } from '@/stores/profile'
 import { updateLocale } from '@/api/profile'
 import { webSiteLink } from '@/shared/links'
+import type { CachedProfile } from '@/shared/profileCookie'
 import { COOKIE_NAME as THEME_COOKIE_NAME, themeCookieStorage } from '@/shared/themeCookie'
 import { useCrossTabSync } from '@/composables/useCrossTabSync'
 import { locales, type LocaleInterface } from '@/lang'
@@ -23,7 +24,16 @@ const { locale } = storeToRefs(localeStore)
 const authStore = useAuthStore()
 const { isLogged } = storeToRefs(authStore)
 const profileStore = useProfileStore()
-const { profile } = storeToRefs(profileStore)
+const { profile, cachedProfile } = storeToRefs(profileStore)
+
+// Falls back to the cached snapshot so the header doesn't flash empty on first paint (#147).
+function cachedDisplayName(cached: CachedProfile): string {
+    return cached.lastName ? `${cached.name} ${cached.lastName}` : cached.name
+}
+const displayName = computed(() => profile.value?.displayName ?? (cachedProfile.value ? cachedDisplayName(cachedProfile.value) : undefined))
+const avatarPhotoUrl = computed(() => profile.value?.photoUrl ?? cachedProfile.value?.photoUrl ?? undefined)
+const avatarInitial = computed(() => (profile.value?.name ?? cachedProfile.value?.name)?.charAt(0))
+
 // Shared with the website via the `cshtrkt` cookie instead of localStorage (see shared/themeCookie.ts).
 const mode = useColorMode({ storageKey: THEME_COOKIE_NAME, storage: themeCookieStorage })
 
@@ -265,12 +275,12 @@ function onLogout() {
                                         variant="subtle"
                                         trailing-icon="i-heroicons-chevron-down-20-solid"
                                         class="cursor-pointer"
-                                        :label="profile?.displayName"
+                                        :label="displayName"
                                     >
                                         <template #leading>
                                             <UAvatar
-                                                :src="profile?.photoUrl ?? undefined"
-                                                :text="profile?.name?.charAt(0)"
+                                                :src="avatarPhotoUrl"
+                                                :text="avatarInitial"
                                                 size="xs"
                                             />
                                         </template>

--- a/src/components/__tests__/AppHeader.spec.ts
+++ b/src/components/__tests__/AppHeader.spec.ts
@@ -5,7 +5,10 @@ import { createPinia, setActivePinia } from 'pinia'
 import AppHeader from '../AppHeader.vue'
 import { useAuthStore } from '@/stores/auth'
 import { useLocaleStore } from '@/stores/locale'
+import { useProfileStore } from '@/stores/profile'
 import { updateLocale } from '@/api/profile'
+import type { User } from '@/api/models/user'
+import type { CachedProfile } from '@/shared/profileCookie'
 
 vi.mock('vue-i18n', () => ({
     useI18n: () => ({
@@ -296,5 +299,59 @@ describe('AppHeader', () => {
         await nextTick()
 
         expect(updateLocale).not.toHaveBeenCalled()
+    })
+
+    it('falls back to the cached profile for display name when the real profile has not loaded yet', async () => {
+        const wrapper = mountHeader()
+        const cached: CachedProfile = {
+            v: 1,
+            id: 1,
+            name: 'Ann',
+            lastName: null,
+            nickName: 'ann',
+            email: 'a@b.c',
+            photoUrl: null,
+            isEmailConfirmed: true,
+            locale: 'en',
+        }
+        useProfileStore().cachedProfile = cached
+        await nextTick()
+
+        expect(wrapper.text()).toContain('Ann')
+    })
+
+    it('prefers the loaded profile over the cached one once it resolves', async () => {
+        const wrapper = mountHeader()
+        const profileStore = useProfileStore()
+        profileStore.cachedProfile = {
+            v: 1,
+            id: 1,
+            name: 'Cached',
+            lastName: null,
+            nickName: 'cached',
+            email: 'a@b.c',
+            photoUrl: null,
+            isEmailConfirmed: true,
+            locale: 'en',
+        }
+        profileStore.profile = {
+            id: 1,
+            name: 'Real',
+            lastName: null,
+            nickName: 'real',
+            email: 'a@b.c',
+            isEmailConfirmed: true,
+            photoUrl: null,
+            defaultCurrencyCode: null,
+            defaultCurrency: null,
+            locale: 'en',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            displayName: 'Real',
+        } as unknown as User
+        await nextTick()
+
+        expect(wrapper.text()).toContain('Real')
+        expect(wrapper.text()).not.toContain('Cached')
     })
 })

--- a/src/shared/__tests__/profileCookie.spec.ts
+++ b/src/shared/__tests__/profileCookie.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+    PROFILE_COOKIE,
+    readCachedProfile,
+    writeCachedProfile,
+    clearCachedProfile,
+    type CachedProfile,
+} from '../profileCookie'
+
+let cookieJar: Record<string, string>
+
+// See themeCookie.spec.ts / sharedCookie.spec.ts for why jsdom's cookie jar is replaced.
+function installCookieJar() {
+    cookieJar = {}
+    Object.defineProperty(document, 'cookie', {
+        configurable: true,
+        get() {
+            return Object.entries(cookieJar)
+                .map(([name, value]) => `${name}=${value}`)
+                .join('; ')
+        },
+        set(raw: string) {
+            const firstPair = raw.split(';')[0]
+            const eqIndex = firstPair.indexOf('=')
+            const name = firstPair.slice(0, eqIndex).trim()
+            const value = firstPair.slice(eqIndex + 1)
+            if (/max-age=0(?:;|$)/.test(raw)) {
+                delete cookieJar[name]
+            } else {
+                cookieJar[name] = value
+            }
+        },
+    })
+}
+
+beforeEach(() => {
+    installCookieJar()
+})
+
+const validProfile: CachedProfile = {
+    v: 1,
+    id: 1,
+    name: 'Ann',
+    lastName: null,
+    nickName: 'ann',
+    email: 'a@b.c',
+    photoUrl: null,
+    isEmailConfirmed: true,
+    locale: 'en',
+}
+
+describe('writeCachedProfile / readCachedProfile', () => {
+    it('round-trips a cached profile', () => {
+        writeCachedProfile(validProfile)
+
+        expect(readCachedProfile()).toEqual(validProfile)
+    })
+
+    it('returns null when the cookie is missing', () => {
+        expect(readCachedProfile()).toBeNull()
+    })
+
+    it('returns null for malformed (non-JSON) cookie content but leaves the cookie intact', () => {
+        document.cookie = `${PROFILE_COOKIE}=${encodeURIComponent('not-json')}`
+
+        expect(readCachedProfile()).toBeNull()
+        expect(document.cookie).toContain(PROFILE_COOKIE)
+    })
+
+    it('returns null for a wrong schema version but leaves the cookie intact', () => {
+        document.cookie = `${PROFILE_COOKIE}=${encodeURIComponent(JSON.stringify({ ...validProfile, v: 2 }))}`
+
+        expect(readCachedProfile()).toBeNull()
+        expect(document.cookie).toContain(PROFILE_COOKIE)
+    })
+
+    it('returns null for a wrong-typed field but leaves the cookie intact', () => {
+        document.cookie = `${PROFILE_COOKIE}=${encodeURIComponent(JSON.stringify({ ...validProfile, id: '1' }))}`
+
+        expect(readCachedProfile()).toBeNull()
+        expect(document.cookie).toContain(PROFILE_COOKIE)
+    })
+})
+
+describe('clearCachedProfile', () => {
+    it('removes the cookie', () => {
+        writeCachedProfile(validProfile)
+
+        clearCachedProfile()
+
+        expect(readCachedProfile()).toBeNull()
+        expect(document.cookie).not.toContain(PROFILE_COOKIE)
+    })
+})

--- a/src/shared/__tests__/sharedCookie.spec.ts
+++ b/src/shared/__tests__/sharedCookie.spec.ts
@@ -95,4 +95,29 @@ describe('readRawCookie / writeRawCookie / deleteRawCookie', () => {
 
         expect(cookieJar.foo).toBeUndefined()
     })
+
+    // Without both deletes a domain-scoped cookie silently survives in production
+    // while appearing to clear in local dev, where cookies are host-only.
+    it('issues both a host-only and a domain-scoped delete when a parent domain resolves', () => {
+        window.__APP_CONFIG__ = { VITE_WEBSITE_URL: 'https://cash-track.app' }
+        document.cookie = 'foo=bar'
+        writes.length = 0
+
+        deleteRawCookie('foo')
+
+        expect(writes.some((w) => !w.includes('Domain=') && /max-age=0(?:;|$)/.test(w))).toBe(true)
+        expect(
+            writes.some((w) => w.includes('Domain=.cash-track.app') && /max-age=0(?:;|$)/.test(w)),
+        ).toBe(true)
+    })
+
+    it('only issues a host-only delete on localhost (no Domain to match)', () => {
+        window.__APP_CONFIG__ = { VITE_WEBSITE_URL: 'http://localhost:3001' }
+        document.cookie = 'foo=bar'
+        writes.length = 0
+
+        deleteRawCookie('foo')
+
+        expect(writes.every((w) => !w.includes('Domain='))).toBe(true)
+    })
 })

--- a/src/shared/profileCookie.ts
+++ b/src/shared/profileCookie.ts
@@ -1,0 +1,66 @@
+import { readRawCookie, writeRawCookie, deleteRawCookie } from './sharedCookie'
+
+// Display cache shared with the website. Never an auth signal.
+export const PROFILE_COOKIE = 'cshtrkp'
+
+// 7 days — outlives the ~6.6 day refresh token, so the cache dies with the session.
+const PROFILE_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
+
+const SCHEMA_VERSION = 1
+
+export interface CachedProfile {
+    v: 1
+    id: number
+    name: string
+    lastName: string | null
+    nickName: string
+    email: string
+    photoUrl: string | null
+    isEmailConfirmed: boolean
+    locale: string
+}
+
+function isCachedProfile(value: unknown): value is CachedProfile {
+    if (!value || typeof value !== 'object') return false
+    const d = value as Record<string, unknown>
+    return (
+        d.v === SCHEMA_VERSION &&
+        typeof d.id === 'number' &&
+        typeof d.name === 'string' &&
+        (d.lastName === null || typeof d.lastName === 'string') &&
+        typeof d.nickName === 'string' &&
+        typeof d.email === 'string' &&
+        (d.photoUrl === null || typeof d.photoUrl === 'string') &&
+        typeof d.isEmailConfirmed === 'boolean' &&
+        typeof d.locale === 'string'
+    )
+}
+
+// Any shape mismatch means "no cache" — must never throw during app startup.
+export function readCachedProfile(): CachedProfile | null {
+    const raw = readRawCookie(PROFILE_COOKIE)
+    if (!raw) return null
+
+    let parsed: unknown
+    try {
+        parsed = JSON.parse(raw)
+    } catch {
+        return null
+    }
+
+    if (!isCachedProfile(parsed)) {
+        return null
+    }
+
+    return parsed
+}
+
+export function writeCachedProfile(profile: CachedProfile) {
+    writeRawCookie(PROFILE_COOKIE, JSON.stringify(profile), PROFILE_COOKIE_MAX_AGE)
+}
+
+// Only on logout or a 401 (see stores/auth.ts, api/client.ts). Never on a parse failure
+// or transient error — the apps deploy independently and a valid cache must survive.
+export function clearCachedProfile() {
+    deleteRawCookie(PROFILE_COOKIE)
+}

--- a/src/shared/sharedCookie.ts
+++ b/src/shared/sharedCookie.ts
@@ -26,20 +26,27 @@ export function readRawCookie(name: string): string | null {
     return pair ? decodeURIComponent(pair.slice(prefix.length)) : null
 }
 
+// Deletes both forms: per RFC 6265 a delete only matches an exact (name, domain, path),
+// so a domain-scoped cookie survives a host-only delete.
 export function deleteRawCookie(name: string) {
     document.cookie = `${name}=; path=/; max-age=0`
+
+    const domain = parentDomain()
+    if (domain && domain !== 'localhost' && !/^[\d.]+$/.test(domain)) {
+        document.cookie = `${name}=; Domain=.${domain}; path=/; max-age=0`
+    }
 }
 
 // Always deletes a host-only sibling first — a domain-scoped and host-only
 // cookie of the same name can otherwise coexist, and reads become ambiguous.
-export function writeRawCookie(name: string, value: string) {
+export function writeRawCookie(name: string, value: string, maxAge: number = COOKIE_MAX_AGE) {
     deleteRawCookie(name)
 
     const domain = parentDomain()
     const attrs = [
         `${name}=${encodeURIComponent(value)}`,
         'path=/',
-        `max-age=${COOKIE_MAX_AGE}`,
+        `max-age=${maxAge}`,
         'SameSite=Lax',
     ]
 

--- a/src/stores/__tests__/auth.spec.ts
+++ b/src/stores/__tests__/auth.spec.ts
@@ -8,7 +8,34 @@ const assignSpy = vi.fn()
 vi.stubGlobal('window', { location: { set href(v: string) { assignSpy(v) } } })
 
 import { useAuthStore } from '../auth'
+import { PROFILE_COOKIE, writeCachedProfile } from '@/shared/profileCookie'
 import type { User } from '@/api/models/user'
+
+let cookieJar: Record<string, string>
+
+// See shared/__tests__/sharedCookie.spec.ts for why jsdom's native cookie jar is replaced.
+function installCookieJar() {
+    cookieJar = {}
+    Object.defineProperty(document, 'cookie', {
+        configurable: true,
+        get() {
+            return Object.entries(cookieJar)
+                .map(([name, value]) => `${name}=${value}`)
+                .join('; ')
+        },
+        set(raw: string) {
+            const firstPair = raw.split(';')[0]
+            const eqIndex = firstPair.indexOf('=')
+            const name = firstPair.slice(0, eqIndex).trim()
+            const value = firstPair.slice(eqIndex + 1)
+            if (/max-age=0(?:;|$)/.test(raw)) {
+                delete cookieJar[name]
+            } else {
+                cookieJar[name] = value
+            }
+        },
+    })
+}
 
 const mockUser = {
     id: 1,
@@ -30,6 +57,7 @@ describe('useAuthStore', () => {
     beforeEach(() => {
         setActivePinia(createPinia())
         vi.clearAllMocks()
+        installCookieJar()
     })
 
     it('initial state is logged out', () => {
@@ -58,5 +86,26 @@ describe('useAuthStore', () => {
         expect(store.isLogged).toBe(false)
         expect(store.isEmailConfirmed).toBe(false)
         expect(assignSpy).toHaveBeenCalledWith('https://website.test/')
+    })
+
+    it('logout() clears the cshtrkp cookie', async () => {
+        writeCachedProfile({
+            v: 1,
+            id: 1,
+            name: 'Alice',
+            lastName: null,
+            nickName: 'alice',
+            email: 'alice@test.com',
+            photoUrl: null,
+            isEmailConfirmed: true,
+            locale: 'en',
+        })
+        expect(document.cookie).toContain(PROFILE_COOKIE)
+
+        const store = useAuthStore()
+        store.login(mockUser)
+        await store.logout()
+
+        expect(document.cookie).not.toContain(PROFILE_COOKIE)
     })
 })

--- a/src/stores/__tests__/profile.spec.ts
+++ b/src/stores/__tests__/profile.spec.ts
@@ -10,7 +10,47 @@ vi.mock('@/api/profile', () => ({ getProfile: mockGetProfile }))
 
 import { useProfileStore } from '../profile'
 import { useAuthStore } from '../auth'
+import { PROFILE_COOKIE, writeCachedProfile } from '@/shared/profileCookie'
 import type { User } from '@/api/models/user'
+
+const mockCachedProfile = {
+    v: 1 as const,
+    id: 1,
+    name: 'Ann',
+    lastName: null,
+    nickName: 'ann',
+    email: 'a@b.c',
+    photoUrl: null,
+    isEmailConfirmed: true,
+    locale: 'en',
+}
+
+let cookieJar: Record<string, string>
+
+// See shared/__tests__/sharedCookie.spec.ts for why jsdom's native cookie jar is replaced.
+// A real jar is needed here: setProfile() writes cshtrkp and cshtrkl in the same call.
+function installCookieJar() {
+    cookieJar = {}
+    Object.defineProperty(document, 'cookie', {
+        configurable: true,
+        get() {
+            return Object.entries(cookieJar)
+                .map(([name, value]) => `${name}=${value}`)
+                .join('; ')
+        },
+        set(raw: string) {
+            const firstPair = raw.split(';')[0]
+            const eqIndex = firstPair.indexOf('=')
+            const name = firstPair.slice(0, eqIndex).trim()
+            const value = firstPair.slice(eqIndex + 1)
+            if (/max-age=0(?:;|$)/.test(raw)) {
+                delete cookieJar[name]
+            } else {
+                cookieJar[name] = value
+            }
+        },
+    })
+}
 
 const mockUser = {
     id: 1,
@@ -32,11 +72,7 @@ describe('useProfileStore', () => {
     beforeEach(() => {
         setActivePinia(createPinia())
         vi.clearAllMocks()
-        // reset cookie state
-        Object.defineProperty(document, 'cookie', {
-            writable: true,
-            value: '',
-        })
+        installCookieJar()
     })
 
     it('initial state: profile null, loading false, failed false, lastError null', () => {
@@ -61,6 +97,37 @@ describe('useProfileStore', () => {
         expect(store.lastError).toBeNull()
     })
 
+    it('loadProfile() success writes the cshtrkp cookie', async () => {
+        mockGetProfile.mockResolvedValue(mockUser)
+        const store = useProfileStore()
+
+        await store.loadProfile()
+
+        expect(document.cookie).toContain(PROFILE_COOKIE)
+    })
+
+    it('loadCachedProfile() seeds cachedProfile and logs in authStore from the cshtrkp cookie', () => {
+        writeCachedProfile(mockCachedProfile)
+        const store = useProfileStore()
+        const authStore = useAuthStore()
+
+        store.loadCachedProfile()
+
+        expect(store.cachedProfile).toEqual(mockCachedProfile)
+        expect(authStore.isLogged).toBe(true)
+        expect(authStore.isEmailConfirmed).toBe(true)
+    })
+
+    it('loadCachedProfile() is a no-op when there is no cached cookie', () => {
+        const store = useProfileStore()
+        const authStore = useAuthStore()
+
+        store.loadCachedProfile()
+
+        expect(store.cachedProfile).toBeNull()
+        expect(authStore.isLogged).toBe(false)
+    })
+
     it('loadProfile() sets failed and lastError on transient error, does NOT call logout, isLogged stays false', async () => {
         const err = new Error('Network timeout')
         mockGetProfile.mockRejectedValue(err)
@@ -77,6 +144,23 @@ describe('useProfileStore', () => {
         expect(store.loading).toBe(false)
         expect(authStore.isLogged).toBe(false)
         expect(logoutSpy).not.toHaveBeenCalled()
+    })
+
+    it('loadProfile() failure resets optimistic state but leaves the cshtrkp cookie intact', async () => {
+        writeCachedProfile(mockCachedProfile)
+        const store = useProfileStore()
+        const authStore = useAuthStore()
+        store.loadCachedProfile()
+        expect(authStore.isLogged).toBe(true)
+
+        mockGetProfile.mockRejectedValue(new Error('Network timeout'))
+        await store.loadProfile()
+
+        expect(store.profile).toBeNull()
+        expect(store.cachedProfile).toBeNull()
+        expect(authStore.isLogged).toBe(false)
+        // A transient failure must not invalidate a still-valid cookie.
+        expect(document.cookie).toContain(PROFILE_COOKIE)
     })
 
     it('loadProfile() resets failed and lastError on retry success', async () => {
@@ -101,6 +185,20 @@ describe('useProfileStore', () => {
         store.updatePhotoUrl('https://cdn.test/photo.jpg')
 
         expect(store.profile?.photoUrl).toBe('https://cdn.test/photo.jpg')
+    })
+
+    it('updatePhotoUrl() updates the cshtrkp cookie', async () => {
+        mockGetProfile.mockResolvedValue(mockUser)
+        const store = useProfileStore()
+        await store.loadProfile()
+
+        store.updatePhotoUrl('https://cdn.test/photo.jpg')
+
+        expect(store.cachedProfile?.photoUrl).toBe('https://cdn.test/photo.jpg')
+        const match = document.cookie.match(/cshtrkp=([^;]*)/)
+        expect(match).not.toBeNull()
+        const decoded = JSON.parse(decodeURIComponent(match![1]))
+        expect(decoded.photoUrl).toBe('https://cdn.test/photo.jpg')
     })
 
     it('updatePhotoUrl() is a no-op when profile is null', () => {

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,16 +1,22 @@
 import { shallowRef } from 'vue'
 import { defineStore } from 'pinia'
-import type { User } from '@/api/models/user'
 import { logout as apiLogout } from '@/api/auth'
 import { webSiteLink } from '@/shared/links'
+import { clearCachedProfile } from '@/shared/profileCookie'
 
 export const useAuthStore = defineStore('auth', () => {
     const isLogged = shallowRef(false)
     const isEmailConfirmed = shallowRef(false)
 
-    function login(profile: User) {
+    // Structural param so both User and the leaner CachedProfile can seed this.
+    function login(profile: { isEmailConfirmed: boolean }) {
         isLogged.value = true
         isEmailConfirmed.value = profile.isEmailConfirmed
+    }
+
+    function reset() {
+        isLogged.value = false
+        isEmailConfirmed.value = false
     }
 
     async function logout() {
@@ -19,10 +25,10 @@ export const useAuthStore = defineStore('auth', () => {
         } catch {
             // redirect regardless
         }
-        isLogged.value = false
-        isEmailConfirmed.value = false
+        reset()
+        clearCachedProfile()
         window.location.href = webSiteLink('/')
     }
 
-    return { isLogged, isEmailConfirmed, login, logout }
+    return { isLogged, isEmailConfirmed, login, reset, logout }
 })

--- a/src/stores/profile.ts
+++ b/src/stores/profile.ts
@@ -4,15 +4,47 @@ import type { User } from '@/api/models/user'
 import { getProfile } from '@/api/profile'
 import { useAuthStore } from './auth'
 import { useLocaleStore } from './locale'
+import {
+    type CachedProfile,
+    readCachedProfile,
+    writeCachedProfile,
+} from '@/shared/profileCookie'
+
+function toCachedProfile(user: User): CachedProfile {
+    return {
+        v: 1,
+        id: user.id,
+        name: user.name,
+        lastName: user.lastName,
+        nickName: user.nickName,
+        email: user.email,
+        photoUrl: user.photoUrl,
+        isEmailConfirmed: user.isEmailConfirmed,
+        locale: user.locale,
+    }
+}
 
 export const useProfileStore = defineStore('profile', () => {
     const profile = shallowRef<User | null>(null)
+    const cachedProfile = shallowRef<CachedProfile | null>(null)
     const loading = shallowRef(false)
     const failed = shallowRef(false)
     const lastError = shallowRef<unknown>(null)
 
+    // Called from App.vue so store creation stays side-effect free — mirrors loadCachedLocale().
+    function loadCachedProfile() {
+        const cached = readCachedProfile()
+        cachedProfile.value = cached
+        if (cached) {
+            useAuthStore().login(cached)
+        }
+    }
+
     function setProfile(user: User) {
         profile.value = user
+        const cached = toCachedProfile(user)
+        cachedProfile.value = cached
+        writeCachedProfile(cached)
         useAuthStore().login(user)
         useLocaleStore().localeChange(user.locale as 'en' | 'uk')
     }
@@ -26,6 +58,11 @@ export const useProfileStore = defineStore('profile', () => {
         } catch (error) {
             failed.value = true
             lastError.value = error
+            // Drop the optimistic state or isLogged stays true and App.vue shows a stale
+            // header instead of the retry alert. The cookie itself is left alone.
+            profile.value = null
+            cachedProfile.value = null
+            useAuthStore().reset()
         } finally {
             loading.value = false
         }
@@ -34,7 +71,20 @@ export const useProfileStore = defineStore('profile', () => {
     function updatePhotoUrl(url: string) {
         if (!profile.value) return
         profile.value = { ...profile.value, photoUrl: url } as User
+        const cached = toCachedProfile(profile.value)
+        cachedProfile.value = cached
+        writeCachedProfile(cached)
     }
 
-    return { profile, loading, failed, lastError, loadProfile, setProfile, updatePhotoUrl }
+    return {
+        profile,
+        cachedProfile,
+        loading,
+        failed,
+        lastError,
+        loadCachedProfile,
+        loadProfile,
+        setProfile,
+        updatePhotoUrl,
+    }
 })


### PR DESCRIPTION
## Problem

On first load the page header shows no profile information — the avatar and name are missing until `GET /profile` resolves, then pop in. The same flash happens on the marketing website, so the fix has to be shared between the two apps.

Closes #147

## Changes

- **`src/shared/profileCookie.ts` (new)** — read/write/clear a `cshtrkp` cookie holding the profile's display fields (`id`, `name`, `lastName`, `nickName`, `email`, `photoUrl`, `isEmailConfirmed`, `locale`) plus a `v` schema tag. Domain-scoped to the parent domain so `my.cash-track.app` and `cash-track.app` share one cache. 7-day TTL — just past the ~6.6 day refresh token, so an abandoned session's cache expires with the session. The reader is strict: a missing cookie, non-JSON, a wrong `v` or any wrong-typed field is treated as "no cache" and never throws into app startup.
- **`src/stores/profile.ts`** — `loadCachedProfile()` seeds `cachedProfile` and marks the auth store logged-in; `setProfile()` and `updatePhotoUrl()` refresh the cookie. Called from `App.vue`, so creating the store stays side-effect free.
- **`src/components/AppHeader.vue`** — name, avatar photo and avatar initial fall back to the cached snapshot until the real profile arrives.
- **Clearing is deliberately narrow** — logout, or a 401 that reached the client. A 401 only reaches the client when the gateway's own token refresh failed (a transient refresh problem surfaces as a 503 with cookies untouched), so it is proof the session is dead. A network error, a 5xx or a failed profile load resets only the in-memory state and leaves the cookie for the next successful load.
- **Bug fix, `src/shared/sharedCookie.ts`** — `deleteRawCookie()` only issued a host-only delete. Per RFC 6265 a delete matches on exact (name, domain, path), so the domain-scoped `cshtrkt` / `cshtrkl` cookies were never actually removed in production, while appearing to clear in local dev where cookies are host-only. It now issues both forms. This predates #147 but is on the same code path; happy to split it out if preferred.

The website side is cash-track/website#92 — same cookie name, same schema, same clearing rules.

## Verification

Reviewed against the requirements over three rounds until the reviewer had nothing material left to raise.

**Unit — `npm run test:unit -- --run`:** 780 passed / 89 files. New coverage for the cookie codec (round-trip, every rejected shape, schema-version mismatch), the store (cache seeding, cookie write on load/photo update, cookie survives a transient failure), the 401 interceptor and both delete forms.

**E2E — full suite, branch vs `origin/master`:** branch 36 failed / 161 passed, master 41 failed / 154 passed. 21 cases fail on both; the branch-only and master-only sets are both dominated by `POST /api/wallets -> 503` from the shared dev account. Master fails worse — no regression attributable to this change. Two new cases: the cached name renders while `GET /profile` is held pending, and an intercepted 401 clears `cshtrkp`.

**Browser (dev stack):** `cshtrkp` is written with `domain=.dev-cash-track.app`, `path=/`, `httpOnly=false`, `secure=true`, expiring in 7.00 days; the value is valid `v=1` JSON with no auth material; it is readable from `https://dev-cash-track.app` with the same profile id; and the header shows the user's name while `/api/profile` is still pending.

`npm run type-check`, `npm run lint` (0 errors) and `npm run build` all clean.