### PR TITLE
feat(frontend): move create charge entry point into the charges list

### DIFF
--- a/e2e/charges-create.spec.ts
+++ b/e2e/charges-create.spec.ts
@@ -1,5 +1,5 @@
-// S8 — Charge create form (ChargeCreate inside WalletView)
-// CC-01..CC-10
+// S8 — Charge create form (ChargeCreate inline in ChargesList, issue #111)
+// CC-01..CC-12
 import { test, expect } from '@playwright/test'
 import {
     label, labelStrings,

--- a/e2e/charges-list.spec.ts
+++ b/e2e/charges-list.spec.ts
@@ -1,5 +1,5 @@
 // S11 — Charges list within wallet detail (ChargesList, ChargeItem)
-// CL-01..CL-09
+// CL-01..CL-10
 import { test, expect } from '@playwright/test'
 import {
     label, labelStrings,
@@ -90,7 +90,7 @@ function makeCharge(walletId: number, overrides: Record<string, unknown> = {}) {
 
 test.describe('S11 — Charges List', () => {
 
-    // CL-01 — Loading overlay visible while charges GET is delayed @smoke
+    // CL-01 — Loading overlay visible while charges GET is delayed; create row stays usable @smoke
     test('CL-01 @smoke loading overlay visible during delayed charges fetch', async ({ request, page }) => {
         const w = await createWalletViaApi(request, { name: `E2E CL01 ${Date.now()}` })
         try {
@@ -101,6 +101,12 @@ test.describe('S11 — Charges List', () => {
 
             // Loading overlay should be visible while request is held
             await expect(chargesLoadingOverlay(page)).toBeVisible({ timeout: 5000 })
+
+            // click() fails on an intercepted element, so this also proves the
+            // overlay does not cover the create row
+            await expect(charge.newChargeButton(page)).toBeVisible({ timeout: 5000 })
+            await charge.newChargeButton(page).click()
+            await expect(charge.amountInput(page)).toBeVisible({ timeout: 5000 })
 
             // Release and wait for content
             release()
@@ -375,6 +381,40 @@ test.describe('S11 — Charges List', () => {
 
             // New Charge button should not be present on inactive wallet
             await expect(charge.newChargeButton(page)).toBeHidden()
+
+            await assertNoErrorLeak(page)
+        } finally {
+            await deleteWalletViaApi(request, w.id)
+        }
+    })
+
+    // CL-10 — Static create row: first item, above every day group (issue #111)
+    test('CL-10 static create row sits above the first day-group header, outside any group', async ({ request, page }) => {
+        const w = await createWalletViaApi(request, { name: `E2E CL10 ${Date.now()}` })
+        try {
+            const todayCharge = await createChargeViaApi(request, w.id, {
+                title: `E2E CL10 ${Date.now()}`,
+            })
+
+            await page.goto(`/wallets/${w.id}`)
+            await expect(page.getByRole('heading', { level: 2 })).toBeVisible({ timeout: 10000 })
+            await expect(page.getByText(todayCharge.title)).toBeVisible({ timeout: 10000 })
+            await expect(todayHeader(page)).toBeVisible({ timeout: 5000 })
+
+            // The create row's "+" icon is aria-hidden, so it never collides with
+            // the charges.new button beside it
+            const createRowIcon = page.locator('button[aria-hidden="true"]').first()
+            await expect(createRowIcon).toBeVisible({ timeout: 5000 })
+
+            await expect(charge.newChargeButton(page)).toBeVisible({ timeout: 5000 })
+
+            const createBox = await createRowIcon.boundingBox()
+            const headerBox = await todayHeader(page).boundingBox()
+            expect(createBox).not.toBeNull()
+            expect(headerBox).not.toBeNull()
+
+            // Smaller y = rendered above the first group header, so it sits outside every group
+            expect(createBox!.y).toBeLessThan(headerBox!.y)
 
             await assertNoErrorLeak(page)
         } finally {

--- a/e2e/charges-move.spec.ts
+++ b/e2e/charges-move.spec.ts
@@ -42,9 +42,11 @@ const moveErrorAlert = (page: import('@playwright/test').Page) =>
     }).first()
 
 // ChargeItem rows — each outer div wrapping the timeline + content
-// They have class containing "group" and "flex items-stretch"
+// They have class containing "group" and "flex items-stretch". The create row shares
+// that class list, so exclude it by its aria-hidden icon button (issue #111).
 const chargeRows = (page: import('@playwright/test').Page) =>
     page.locator('div.group.flex.items-stretch.-mx-4')
+        .filter({ hasNot: page.locator('button[aria-hidden="true"]') })
 
 test.describe('S17 — Charges Move', () => {
 

--- a/e2e/responsive.mobile.spec.ts
+++ b/e2e/responsive.mobile.spec.ts
@@ -388,8 +388,8 @@ test.describe('S21 — Responsive / Mobile', () => {
             await expect(wallet.detailHeading(page)).toBeVisible({ timeout: 10000 })
             await expect(page.getByText(`E2E RM10 second ${stamp}`)).toBeVisible({ timeout: 10000 })
 
-            // ChargeItem root is the only .items-stretch in the app; its first child is
-            // the timeline column. Measure boxes rather than assert Tailwind classes.
+            // ChargeItem and the create row both use .items-stretch with the timeline
+            // column first. Measure boxes rather than assert Tailwind classes.
             const overflow = await page.evaluate(() => {
                 const rows = Array.from(document.querySelectorAll('.items-stretch'))
                 return rows.map(row => {
@@ -401,7 +401,8 @@ test.describe('S21 — Responsive / Mobile', () => {
                 })
             })
 
-            expect(overflow.length).toBeGreaterThanOrEqual(2)
+            // create row + 2 charge rows
+            expect(overflow.length).toBeGreaterThanOrEqual(3)
             for (const box of overflow) {
                 expect(box).not.toBeNull()
                 expect(box!.above).toBeLessThanOrEqual(0.5)

--- a/src/components/wallets/charges/ChargesList.vue
+++ b/src/components/wallets/charges/ChargesList.vue
@@ -8,6 +8,7 @@ import type { Tag } from '@/api/models/tag'
 import type { Pagination } from '@/api/models/pagination'
 import type { FilterState } from './ChargesFilter.vue'
 import ChargeItem from './ChargeItem.vue'
+import ChargeCreate from './ChargeCreate.vue'
 import { useWalletsStore } from '@/stores/wallets'
 import { useMoneyFormatter } from '@/composables/useMoneyFormatter'
 import { useChargesGrouping } from '@/composables/useChargesGrouping'
@@ -24,6 +25,7 @@ const emit = defineEmits<{
     'charge-deleted': [chargeId: string]
     'charges-moved': []
     'tag-selected': [tagId: number]
+    'charge-created': [charge: Charge]
 }>()
 
 const { t, locale } = useI18n()
@@ -42,6 +44,10 @@ const lastError = ref<unknown>(null)
 const currentPage = ref(1)
 const sentinelRef = ref<HTMLElement | null>(null)
 let observer: IntersectionObserver | null = null
+
+// Static create-row state — top-level item, outside grouping/filtering/pagination
+const isCreateOpen = ref(false)
+const titleAutocompleteOpen = ref(false)
 
 const { chargesGrouped } = useChargesGrouping(charges, t, locale)
 
@@ -167,6 +173,24 @@ function onChargeDeleted(chargeId: string) {
     emit('charge-deleted', chargeId)
 }
 
+function openCreate() {
+    if (isCreateOpen.value) return
+    isCreateOpen.value = true
+}
+
+// The button stays visible while the form is open, so it toggles
+function toggleCreate() {
+    isCreateOpen.value = !isCreateOpen.value
+}
+
+function closeCreate() {
+    isCreateOpen.value = false
+}
+
+watch(isCreateOpen, (open) => {
+    if (!open) titleAutocompleteOpen.value = false
+})
+
 function onChargeCreated(charge: Charge) {
     // Insert at the correct position in the descending-dateTime list
     const index = charges.value.findIndex(c => c.dateTime < charge.dateTime)
@@ -177,6 +201,8 @@ function onChargeCreated(charge: Charge) {
         next.splice(index, 0, charge)
         charges.value = next
     }
+    closeCreate()
+    emit('charge-created', charge)
 }
 
 function setupObserver() {
@@ -200,8 +226,10 @@ function observeSentinel() {
 // Combined into one watcher: on a wallet switch the parent resets the filter and
 // sets the new wallet in the same tick, so two separate watchers would each fire a
 // load. An array watch fires once when both change together → a single fetch.
+// closeCreate() is deliberate: the open form targets the current wallet and filter.
 watch([() => props.wallet.id, () => props.filter], () => {
     selectedCharges.value = []
+    closeCreate()
     loadCharges(1)
 }, { deep: true })
 
@@ -221,132 +249,191 @@ onMounted(() => {
 onUnmounted(() => {
     observer?.disconnect()
 })
-
-defineExpose({ onChargeCreated })
 </script>
 
 <template>
-    <div class="relative">
-        <!-- Loading overlay -->
-        <div v-if="loading" class="absolute inset-0 z-10 flex items-start justify-center pt-8 bg-default/60 backdrop-blur-xs rounded-lg">
-            <UIcon name="i-lucide-loader-circle" class="size-6 animate-spin text-muted" />
-            <span class="ml-2 text-muted">{{ t('charges.loading') }}</span>
+    <div>
+        <!-- Static create row: first item, never part of a day group. Sits outside the
+             loading wrapper below so it stays clickable while charges reload. -->
+        <div
+            v-if="wallet.isActive"
+            class="group flex items-stretch transition-colors -mx-4 sm:mx-0 sm:px-4 sm:py-2"
+            :class="isCreateOpen ? 'bg-elevated' : 'hover:bg-muted'"
+        >
+            <!-- Timeline column: mirrors ChargeItem's -my-2/py-2 pairing (issue #108) -->
+            <div class="flex flex-col items-center w-10 shrink-0 sm:-my-2">
+                <div class="w-px h-3 sm:h-5 bg-black/10 dark:bg-white/10" />
+                <button
+                    type="button"
+                    aria-hidden="true"
+                    tabindex="-1"
+                    class="flex items-center justify-center size-7 rounded-full border-0 shrink-0 border-primary text-primary transition-colors"
+                    @click="openCreate"
+                >
+                    <UIcon name="i-lucide-plus" class="size-6" />
+                </button>
+                <div class="w-px flex-1 bg-black/10 dark:bg-white/10" />
+            </div>
+
+            <!-- Main content -->
+            <div class="flex-1 min-w-0 py-3 pr-4">
+                <UButton
+                    variant="solid"
+                    color="primary"
+                    size="md"
+                    icon="i-lucide-plus"
+                    @click="toggleCreate"
+                >
+                    {{ t('charges.new') }}
+                </UButton>
+                <UCollapsible
+                    v-model:open="isCreateOpen"
+                    :ui="{ content: titleAutocompleteOpen ? 'overflow-visible' : '' }"
+                >
+                    <template #content>
+                        <ChargeCreate
+                            class="mt-4"
+                            :wallet="wallet"
+                            :wallet-tags="walletTags"
+                            @charge-created="onChargeCreated"
+                            @cancelled="closeCreate"
+                            @dropdown-open-change="titleAutocompleteOpen = $event"
+                        />
+                    </template>
+                </UCollapsible>
+            </div>
         </div>
 
-        <!-- Error -->
-        <LoadErrorAlert
-            v-if="error && !loading"
-            :title="error"
-            :error="lastError"
-            retryable
-            class="my-3"
-            @retry="loadCharges(1)"
-        />
-
-        <!-- Charges list -->
-        <div v-if="!error">
-            <!-- Move toolbar -->
-            <div
-                v-if="selectedCharges.length && moveTargetWallets.length"
-                class="flex items-center gap-2 px-4 py-2 -mx-4 sm:mx-0 bg-elevated flex-wrap"
-            >
-                <UDropdownMenu :items="moveDropdownItems">
-                    <UButton
-                        variant="solid"
-                        color="primary"
-                        size="md"
-                        icon="i-lucide-move"
-                        :loading="moveLoading"
-                    >
-                        {{ t('charges.move') }}
-                    </UButton>
-                </UDropdownMenu>
-
-                <UButton
-                    variant="soft"
-                    color="neutral"
-                    size="md"
-                    @click="selectedCharges = []"
-                >
-                    {{ t('charges.clearSelection') }}
-                </UButton>
-
-                <span class="text-sm text-muted ml-auto">
-                    {{ t('charges.selectedCount', { count: selectedCharges.length }) }}
-                </span>
-
-                <UAlert
-                    v-if="moveError"
-                    color="error"
-                    variant="soft"
-                    icon="i-lucide-circle-alert"
-                    :description="moveError"
-                    close
-                    class="basis-full"
-                    @update:open="moveError = null"
-                />
+        <div class="relative">
+            <!-- Loading overlay: scoped to this wrapper, so it never covers the create row -->
+            <div v-if="loading" class="absolute inset-0 z-10 flex items-start justify-center pt-8 bg-default/60 backdrop-blur-xs rounded-lg">
+                <UIcon name="i-lucide-loader-circle" class="size-6 animate-spin text-muted" />
+                <span class="ml-2 text-muted">{{ t('charges.loading') }}</span>
             </div>
 
-            <template v-for="[group, groupCharges] in chargesGrouped" :key="group">
-                <!-- Group header -->
+            <!-- Error -->
+            <LoadErrorAlert
+                v-if="error && !loading"
+                :title="error"
+                :error="lastError"
+                retryable
+                class="my-3"
+                @retry="loadCharges(1)"
+            />
+
+            <!-- Charges list -->
+            <div v-if="!error">
+                <!-- Move toolbar -->
                 <div
-                    class="group px-0 sm:px-4 py-2 -mx-4 sm:mx-0 transition-colors"
-                    :class="isGroupSelected(groupCharges) ? 'bg-elevated' : (wallet.isActive ? 'hover:bg-muted' : '')"
+                    v-if="selectedCharges.length && moveTargetWallets.length"
+                    class="flex items-center gap-2 px-4 py-2 -mx-4 sm:mx-0 bg-elevated flex-wrap"
                 >
-                    <div class="flex items-center gap-2">
-                        <!-- Explicit select control (active wallets only) -->
-                        <UTooltip v-if="wallet.isActive" :text="t('charges.selectGroup')" :arrow="true">
-                            <button
-                                type="button"
-                                class="size-6 rounded-full border transition-colors shrink-0 cursor-pointer flex items-center justify-center ml-2"
-                                :class="[
-                                    isGroupSelected(groupCharges)
-                                        ? 'bg-primary border-primary text-white'
-                                        : 'border-default text-muted hover:border-primary hover:text-primary',
-                                    isGroupSelected(groupCharges) ? '' : 'invisible group-hover:visible active:visible pointer-coarse:visible',
-                                ]"
-                                :aria-label="t('charges.selectGroup')"
-                                :aria-pressed="isGroupSelected(groupCharges)"
-                                @click="onToggleGroup(groupCharges)"
-                            >
-                                <UIcon name="i-lucide-check" class="size-4" />
-                            </button>
-                        </UTooltip>
-                        <!-- Decorative divider for inactive wallets -->
-                        <div v-else class="w-6 shrink-0 h-px transition-colors bg-black/10 dark:bg-white/10 ml-2" />
-                        <span class="text-sm text-muted">{{ group }}</span>
-                        <div class="flex-1 h-px transition-colors" :class="isGroupSelected(groupCharges) ? '' : 'bg-black/10 dark:bg-white/10'" />
-                    </div>
+                    <UDropdownMenu :items="moveDropdownItems">
+                        <UButton
+                            variant="solid"
+                            color="primary"
+                            size="md"
+                            icon="i-lucide-move"
+                            :loading="moveLoading"
+                        >
+                            {{ t('charges.move') }}
+                        </UButton>
+                    </UDropdownMenu>
+
+                    <UButton
+                        variant="soft"
+                        color="neutral"
+                        size="md"
+                        @click="selectedCharges = []"
+                    >
+                        {{ t('charges.clearSelection') }}
+                    </UButton>
+
+                    <span class="text-sm text-muted ml-auto">
+                        {{ t('charges.selectedCount', { count: selectedCharges.length }) }}
+                    </span>
+
+                    <UAlert
+                        v-if="moveError"
+                        color="error"
+                        variant="soft"
+                        icon="i-lucide-circle-alert"
+                        :description="moveError"
+                        close
+                        class="basis-full"
+                        @update:open="moveError = null"
+                    />
                 </div>
 
-                <ChargeItem
-                    v-for="charge in groupCharges"
-                    :key="charge.id"
-                    :charge="charge"
-                    :wallet="wallet"
-                    :wallet-tags="walletTags"
-                    :read-only="!wallet.isActive"
-                    :selectable="wallet.isActive"
-                    :selected="selectedCharges.some(c => c.id === charge.id)"
-                    @updated="onChargeUpdated"
-                    @deleted="onChargeDeleted"
-                    @tag-selected="(tagId) => emit('tag-selected', tagId)"
-                    @toggle-selected="onToggleSelected"
-                />
-            </template>
+                <template v-for="[group, groupCharges] in chargesGrouped" :key="group">
+                    <!-- Group header -->
+                    <div
+                        class="group px-0 sm:px-4 py-2 -mx-4 sm:mx-0 transition-colors"
+                        :class="isGroupSelected(groupCharges) ? 'bg-elevated' : (wallet.isActive ? 'hover:bg-muted' : '')"
+                    >
+                        <div class="flex items-center gap-2">
+                            <!-- Timeline slot: the connector runs through the header and yields
+                                 to the select control. -my-2 spans the row's py-2 (issue #108) -->
+                            <div class="relative flex items-center justify-center w-6 shrink-0 ml-2 self-stretch -my-2">
+                                <div
+                                    v-if="wallet.isActive && !isGroupSelected(groupCharges)"
+                                    class="absolute inset-y-0 left-1/2 -translate-x-1/2 w-px bg-black/10 dark:bg-white/10 group-hover:invisible pointer-coarse:invisible"
+                                />
+                                <!-- Explicit select control (active wallets only) -->
+                                <UTooltip v-if="wallet.isActive" :text="t('charges.selectGroup')" :arrow="true">
+                                    <button
+                                        type="button"
+                                        class="relative size-6 rounded-full border transition-colors shrink-0 cursor-pointer flex items-center justify-center"
+                                        :class="[
+                                            isGroupSelected(groupCharges)
+                                                ? 'bg-primary border-primary text-white'
+                                                : 'border-default text-muted hover:border-primary hover:text-primary',
+                                            isGroupSelected(groupCharges) ? '' : 'invisible group-hover:visible active:visible pointer-coarse:visible',
+                                        ]"
+                                        :aria-label="t('charges.selectGroup')"
+                                        :aria-pressed="isGroupSelected(groupCharges)"
+                                        @click="onToggleGroup(groupCharges)"
+                                    >
+                                        <UIcon name="i-lucide-check" class="size-4" />
+                                    </button>
+                                </UTooltip>
+                                <!-- Decorative divider for inactive wallets -->
+                                <div v-else class="w-6 shrink-0 h-px transition-colors bg-black/10 dark:bg-white/10" />
+                            </div>
+                            <span class="text-sm text-muted">{{ group }}</span>
+                            <div class="flex-1 h-px transition-colors" :class="isGroupSelected(groupCharges) ? '' : 'bg-black/10 dark:bg-white/10'" />
+                        </div>
+                    </div>
 
-            <!-- Empty state -->
-            <div v-if="charges.length === 0" class="py-8 text-center text-muted">
-                {{ t('charges.empty') }}
-            </div>
+                    <ChargeItem
+                        v-for="charge in groupCharges"
+                        :key="charge.id"
+                        :charge="charge"
+                        :wallet="wallet"
+                        :wallet-tags="walletTags"
+                        :read-only="!wallet.isActive"
+                        :selectable="wallet.isActive"
+                        :selected="selectedCharges.some(c => c.id === charge.id)"
+                        @updated="onChargeUpdated"
+                        @deleted="onChargeDeleted"
+                        @tag-selected="(tagId) => emit('tag-selected', tagId)"
+                        @toggle-selected="onToggleSelected"
+                    />
+                </template>
 
-            <!-- Infinite scroll sentinel -->
-            <div ref="sentinelRef" class="h-1" />
+                <!-- Empty state -->
+                <div v-if="charges.length === 0" class="py-8 text-center text-muted">
+                    {{ t('charges.empty') }}
+                </div>
 
-            <!-- Loading more spinner -->
-            <div v-if="loadingMore" class="flex justify-center py-4">
-                <UIcon name="i-lucide-loader-circle" class="size-5 animate-spin text-muted" />
-                <span class="ml-2 text-sm text-muted">{{ t('charges.loadingMore') }}</span>
+                <!-- Infinite scroll sentinel -->
+                <div ref="sentinelRef" class="h-1" />
+
+                <!-- Loading more spinner -->
+                <div v-if="loadingMore" class="flex justify-center py-4">
+                    <UIcon name="i-lucide-loader-circle" class="size-5 animate-spin text-muted" />
+                    <span class="ml-2 text-sm text-muted">{{ t('charges.loadingMore') }}</span>
+                </div>
             </div>
         </div>
     </div>

--- a/src/components/wallets/charges/__tests__/ChargeTitleFormInput.spec.ts
+++ b/src/components/wallets/charges/__tests__/ChargeTitleFormInput.spec.ts
@@ -111,7 +111,7 @@ describe('ChargeTitleFormInput', () => {
     it('emits dropdown-open-change whenever the internal dropdownOpen ref toggles', async () => {
         // Ancestors (e.g. a UCollapsible with overflow-hidden) rely on this event to
         // temporarily allow overflow while the suggestions listbox is open — see
-        // WalletView.vue's titleAutocompleteOpen (issue #110).
+        // ChargesList.vue's titleAutocompleteOpen (issue #110).
         const wrapper = mountInput()
         const vm = wrapper.vm as unknown as { dropdownOpen: boolean }
 

--- a/src/components/wallets/charges/__tests__/ChargesList.spec.ts
+++ b/src/components/wallets/charges/__tests__/ChargesList.spec.ts
@@ -327,6 +327,32 @@ describe('ChargesList', () => {
         expect(wrapper.find('[role="button"]').exists()).toBe(false)
     })
 
+    it('group header draws the timeline connector while the select control is hidden', async () => {
+        const todayCharge = makeTodayCharge('td-connector')
+        mockGetCharges.mockResolvedValue({ data: [todayCharge], pagination: makePagination() })
+
+        const wrapper = shallowMount(ChargesList, {
+            props: { wallet: makeWallet(1) },
+            global: { stubs: { Tooltip: tooltipStub, UTooltip: tooltipStub } },
+        })
+
+        await vi.waitFor(() => expect(mockGetCharges).toHaveBeenCalledTimes(1))
+        await nextTick()
+
+        // One connector per group header, so the timeline reads as one unbroken line
+        const connector = wrapper.find('div.absolute.w-px')
+        expect(connector.exists()).toBe(true)
+        // It yields to the select control exactly when that control appears
+        expect(connector.classes()).toContain('group-hover:invisible')
+        expect(connector.classes()).toContain('pointer-coarse:invisible')
+
+        // Selecting the group pins the control visible, so the connector gives way
+        await wrapper.find('[aria-label="charges.selectGroup"]').trigger('click')
+        await nextTick()
+
+        expect(wrapper.find('div.absolute.w-px').exists()).toBe(false)
+    })
+
     it('clicking the select-group control toggles the whole group', async () => {
         const todayCharge = makeTodayCharge('td-click')
         mockGetCharges.mockResolvedValue({ data: [todayCharge], pagination: makePagination() })
@@ -402,6 +428,8 @@ describe('ChargesList', () => {
         expect(wrapper.find('[aria-label="charges.selectGroup"]').exists()).toBe(false)
         // No role="button" either
         expect(wrapper.find('[role="button"]').exists()).toBe(false)
+        // The decorative dash stands in for the control, so no vertical connector here
+        expect(wrapper.find('div.absolute.w-px').exists()).toBe(false)
     })
 
     it('clears selectedCharges and removes moved charges from local list on success', async () => {
@@ -473,5 +501,254 @@ describe('ChargesList', () => {
 
         // After successful reload the error should be cleared
         expect(vm.error).toBeNull()
+    })
+
+    // The create-charge entry point is a static top-level row, never part of a day group
+    describe('static create row (issue #111)', () => {
+        // shallowMount's auto-stub swallows slot content, so both stubs render slots
+        const collapsibleStub = {
+            name: 'Collapsible',
+            template: '<div><slot v-if="open" name="content" /></div>',
+            props: ['open', 'unmountOnHide', 'ui'],
+        }
+        const buttonStub = {
+            name: 'Button',
+            template: '<button @click="$emit(\'click\')"><slot /></button>',
+            props: ['variant', 'color', 'size', 'icon'],
+            emits: ['click'],
+        }
+        const stubs = {
+            UCollapsible: collapsibleStub,
+            Collapsible: collapsibleStub,
+            UButton: buttonStub,
+            Button: buttonStub,
+        }
+
+        it('renders the create row for an active wallet, before the first group header', async () => {
+            const todayCharge = makeTodayCharge()
+            mockGetCharges.mockResolvedValue({ data: [todayCharge], pagination: makePagination() })
+
+            const wrapper = shallowMount(ChargesList, {
+                props: { wallet: makeWallet(1) },
+                global: { stubs },
+            })
+
+            await vi.waitFor(() => expect(mockGetCharges).toHaveBeenCalledTimes(1))
+            await nextTick()
+
+            const text = wrapper.text()
+            const createIndex = text.indexOf('charges.new')
+            const groupIndex = text.indexOf('charges.today')
+            expect(createIndex).toBeGreaterThanOrEqual(0)
+            expect(groupIndex).toBeGreaterThanOrEqual(0)
+            expect(createIndex).toBeLessThan(groupIndex)
+
+            // The "+" icon button is decorative — hidden from the accessibility tree
+            expect(wrapper.find('button[aria-hidden="true"]').exists()).toBe(true)
+        })
+
+        it('stays visible and clickable while charges are loading, unblurred and uncovered by the loading overlay', async () => {
+            // A never-resolving promise keeps `loading` true
+            let resolveGetCharges: (value: { data: Charge[]; pagination: Pagination }) => void = () => {}
+            mockGetCharges.mockReturnValue(new Promise((resolve) => {
+                resolveGetCharges = resolve
+            }))
+
+            const wrapper = shallowMount(ChargesList, {
+                props: { wallet: makeWallet(1) },
+                global: { stubs },
+            })
+            await nextTick()
+
+            expect(wrapper.text()).toContain('charges.loading')
+
+            // The create row stays clickable under the overlay
+            const label = wrapper.findAll('button').find(b => b.text() === 'charges.new')
+            expect(label).toBeTruthy()
+            await label!.trigger('click')
+            await nextTick()
+
+            const vm = wrapper.vm as unknown as { isCreateOpen: boolean }
+            expect(vm.isCreateOpen).toBe(true)
+
+            // The overlay's positioning context must not contain the create row
+            const overlay = wrapper.find('.absolute.inset-0.z-10')
+            expect(overlay.exists()).toBe(true)
+            const relativeAncestor = overlay.element.closest('.relative')
+            expect(relativeAncestor).toBeTruthy()
+            const createRow = wrapper.find('button[aria-hidden="true"]').element.closest('.group.flex.items-stretch')
+            expect(createRow).toBeTruthy()
+            expect(relativeAncestor!.contains(createRow!)).toBe(false)
+
+            // Settle the pending fetch so it doesn't leak into other tests
+            resolveGetCharges({ data: [], pagination: makePagination() })
+            await nextTick()
+        })
+
+        it('does not render the create row for an inactive wallet', async () => {
+            const inactiveWallet = new Wallet({
+                id: 1,
+                name: 'Wallet 1',
+                slug: 'wallet-1',
+                totalAmount: 0,
+                isActive: false,
+                isPublic: false,
+                isArchived: true,
+                defaultCurrencyCode: 'USD',
+                defaultCurrency: usd,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                users: [],
+                latestCharges: [],
+            })
+            mockGetCharges.mockResolvedValue({ data: [makeCharge('c-inactive')], pagination: makePagination() })
+
+            const wrapper = shallowMount(ChargesList, {
+                props: { wallet: inactiveWallet },
+                global: { stubs },
+            })
+
+            await vi.waitFor(() => expect(mockGetCharges).toHaveBeenCalledTimes(1))
+            await nextTick()
+
+            expect(wrapper.find('button[aria-hidden="true"]').exists()).toBe(false)
+            expect(wrapper.text()).not.toContain('charges.new')
+        })
+
+        it('opens the inline ChargeCreate form on click and keeps the button visible', async () => {
+            mockGetCharges.mockResolvedValue({ data: [makeCharge()], pagination: makePagination() })
+
+            const wrapper = shallowMount(ChargesList, {
+                props: { wallet: makeWallet(1) },
+                global: { stubs },
+            })
+
+            await vi.waitFor(() => expect(mockGetCharges).toHaveBeenCalledTimes(1))
+            await nextTick()
+
+            expect(wrapper.findComponent({ name: 'ChargeCreate' }).exists()).toBe(false)
+
+            const label = wrapper.findAll('button').find(b => b.text() === 'charges.new')
+            expect(label).toBeTruthy()
+            await label!.trigger('click')
+            await nextTick()
+
+            const vm = wrapper.vm as unknown as { isCreateOpen: boolean }
+            expect(vm.isCreateOpen).toBe(true)
+            expect(wrapper.findComponent({ name: 'ChargeCreate' }).exists()).toBe(true)
+            // The button stays visible alongside the open form and toggles it shut.
+            const stillThere = wrapper.findAll('button').find(b => b.text() === 'charges.new')
+            expect(stillThere).toBeTruthy()
+
+            await stillThere!.trigger('click')
+            await nextTick()
+
+            expect(vm.isCreateOpen).toBe(false)
+            expect(wrapper.findComponent({ name: 'ChargeCreate' }).exists()).toBe(false)
+            expect(wrapper.findAll('button').some(b => b.text() === 'charges.new')).toBe(true)
+        })
+
+        it('inserts the created charge, closes the form, and emits charge-created', async () => {
+            mockGetCharges.mockResolvedValue({ data: [makeCharge('c-existing')], pagination: makePagination() })
+
+            const wrapper = shallowMount(ChargesList, {
+                props: { wallet: makeWallet(1) },
+                global: { stubs },
+            })
+
+            await vi.waitFor(() => expect(mockGetCharges).toHaveBeenCalledTimes(1))
+            await nextTick()
+
+            const vm = wrapper.vm as unknown as { isCreateOpen: boolean; charges: Charge[] }
+            vm.isCreateOpen = true
+            await nextTick()
+
+            const chargeCreate = wrapper.findComponent({ name: 'ChargeCreate' })
+            expect(chargeCreate.exists()).toBe(true)
+
+            const newCharge = makeCharge('c-new', new Date('2030-01-01T00:00:00'))
+            await chargeCreate.vm.$emit('charge-created', newCharge)
+
+            expect(vm.charges.some(c => c.id === 'c-new')).toBe(true)
+            expect(vm.isCreateOpen).toBe(false)
+            const events = wrapper.emitted('charge-created')
+            expect(events).toBeTruthy()
+            expect(events![0]).toEqual([newCharge])
+        })
+
+        it('closes the form when ChargeCreate emits cancelled', async () => {
+            mockGetCharges.mockResolvedValue({ data: [makeCharge()], pagination: makePagination() })
+
+            const wrapper = shallowMount(ChargesList, {
+                props: { wallet: makeWallet(1) },
+                global: { stubs },
+            })
+
+            await vi.waitFor(() => expect(mockGetCharges).toHaveBeenCalledTimes(1))
+            await nextTick()
+
+            const vm = wrapper.vm as unknown as { isCreateOpen: boolean }
+            vm.isCreateOpen = true
+            await nextTick()
+
+            const chargeCreate = wrapper.findComponent({ name: 'ChargeCreate' })
+            await chargeCreate.vm.$emit('cancelled')
+
+            expect(vm.isCreateOpen).toBe(false)
+        })
+
+        it('relays dropdown-open-change into the collapsible overflow-visible override, resetting on close', async () => {
+            mockGetCharges.mockResolvedValue({ data: [makeCharge()], pagination: makePagination() })
+
+            const wrapper = shallowMount(ChargesList, {
+                props: { wallet: makeWallet(1) },
+                global: { stubs },
+            })
+
+            await vi.waitFor(() => expect(mockGetCharges).toHaveBeenCalledTimes(1))
+            await nextTick()
+
+            const vm = wrapper.vm as unknown as { isCreateOpen: boolean }
+            vm.isCreateOpen = true
+            await nextTick()
+
+            const collapsible = wrapper.findComponent({ name: 'Collapsible' })
+            expect(collapsible.exists()).toBe(true)
+            expect(collapsible.props('ui')).toEqual({ content: '' })
+
+            const chargeCreate = wrapper.findComponent({ name: 'ChargeCreate' })
+            await chargeCreate.vm.$emit('dropdown-open-change', true)
+            await nextTick()
+            expect(collapsible.props('ui')).toEqual({ content: 'overflow-visible' })
+
+            // Closing the form resets the override on its own
+            vm.isCreateOpen = false
+            await nextTick()
+            expect(wrapper.findComponent({ name: 'Collapsible' }).props('ui')).toEqual({ content: '' })
+        })
+
+        it('closes the create form when the wallet switches', async () => {
+            mockGetCharges.mockResolvedValue({ data: [makeCharge()], pagination: makePagination() })
+
+            const wrapper = shallowMount(ChargesList, {
+                props: { wallet: makeWallet(1) },
+                global: { stubs },
+            })
+
+            await vi.waitFor(() => expect(mockGetCharges).toHaveBeenCalledTimes(1))
+            await nextTick()
+
+            const vm = wrapper.vm as unknown as { isCreateOpen: boolean }
+            vm.isCreateOpen = true
+            await nextTick()
+            expect(vm.isCreateOpen).toBe(true)
+
+            mockGetCharges.mockResolvedValue({ data: [], pagination: makePagination() })
+            await wrapper.setProps({ wallet: makeWallet(2) })
+            await vi.waitFor(() => expect(mockGetCharges).toHaveBeenCalledTimes(2))
+            await nextTick()
+
+            expect(vm.isCreateOpen).toBe(false)
+        })
     })
 })

--- a/src/views/WalletView.vue
+++ b/src/views/WalletView.vue
@@ -3,7 +3,6 @@ import { shallowRef, ref, computed, onMounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { getWallet, getWalletTotals, getWalletUsers } from '@/api/wallets'
-import type { Charge } from '@/api/models/charge'
 import { getWalletTags } from '@/api/tags'
 import type { Wallet } from '@/api/models/wallet'
 import type { WalletTotal } from '@/api/models/wallet'
@@ -13,7 +12,6 @@ import type { FilterState } from '@/components/wallets/charges/ChargesFilter.vue
 import { useWalletsStore } from '@/stores/wallets'
 import TagChip from '@/components/tags/Tag.vue'
 import WalletHeader from '@/components/wallets/WalletHeader.vue'
-import ChargeCreate from '@/components/wallets/charges/ChargeCreate.vue'
 import ChargesList from '@/components/wallets/charges/ChargesList.vue'
 import ChargesFilter from '@/components/wallets/charges/ChargesFilter.vue'
 import ChargesFlowChart from '@/components/wallets/charges/ChargesFlowChart.vue'
@@ -38,14 +36,11 @@ const loading = ref(false)
 const error = ref<string | null>(null)
 const lastError = ref<unknown>(null)
 
-const showCreateForm = ref(false)
 const showFilters = ref(false)
 const showGraph = ref(false)
 const showLimits = ref(false)
 const showTags = shallowRef(false)
 const filter = ref<FilterState>({ dateFrom: '', dateTo: '' })
-const titleAutocompleteOpen = ref(false)
-const chargesListRef = ref<InstanceType<typeof ChargesList> | null>(null)
 const flowChartRef = ref<InstanceType<typeof ChargesFlowChart> | null>(null)
 const totalChartRef = ref<InstanceType<typeof ChargesTotalChart> | null>(null)
 const limitsRef = ref<InstanceType<typeof WalletLimitsTotal> | null>(null)
@@ -93,9 +88,7 @@ async function refreshTotals() {
     }
 }
 
-function onChargeCreated(charge: Charge) {
-    showCreateForm.value = false
-    chargesListRef.value?.onChargeCreated(charge)
+function onChargeCreated() {
     refreshTotals()
     if (showGraph.value) {
         flowChartRef.value?.reload()
@@ -213,7 +206,6 @@ watch(selectedTags, () => {
 
 onMounted(() => loadWallet())
 watch(() => props.walletID, () => {
-    showCreateForm.value = false
     showFilters.value = false
     showGraph.value = false
     showLimits.value = false
@@ -223,11 +215,7 @@ watch(() => props.walletID, () => {
     loadWallet()
 })
 
-watch(showCreateForm, (open) => {
-    if (!open) titleAutocompleteOpen.value = false
-})
-
-defineExpose({ wallet, error, showCreateForm, showFilters, showGraph, showLimits, showTags })
+defineExpose({ wallet, error, showFilters, showGraph, showLimits, showTags })
 </script>
 
 <template>
@@ -325,36 +313,7 @@ defineExpose({ wallet, error, showCreateForm, showFilters, showGraph, showLimits
                     >
                         {{ t('wallets.filters') }}
                     </UButton>
-                    <UButton
-                        v-if="wallet.isActive"
-                        variant="solid"
-                        color="primary"
-                        size="md"
-                        icon="i-lucide-plus"
-                        @click="showCreateForm = !showCreateForm"
-                    >
-                        {{ t('charges.new') }}
-                    </UButton>
                 </div>
-
-                <!-- Create form -->
-                <UCollapsible
-                    v-if="wallet.isActive"
-                    v-model:open="showCreateForm"
-                    :ui="{ content: titleAutocompleteOpen ? 'overflow-visible' : '' }"
-                >
-                    <template #content>
-                        <div class="border border-default rounded-lg p-4 mb-4">
-                            <ChargeCreate
-                                :wallet="wallet"
-                                :wallet-tags="walletTags"
-                                @charge-created="onChargeCreated"
-                                @cancelled="showCreateForm = false"
-                                @dropdown-open-change="titleAutocompleteOpen = $event"
-                            />
-                        </div>
-                    </template>
-                </UCollapsible>
 
                 <!-- Limits -->
                 <UCollapsible v-model:open="showLimits" :unmount-on-hide="false">
@@ -457,10 +416,10 @@ defineExpose({ wallet, error, showCreateForm, showFilters, showGraph, showLimits
                 <!-- Charges list -->
                 <div class="rounded-lg">
                     <ChargesList
-                        ref="chargesListRef"
                         :wallet="wallet"
                         :wallet-tags="walletTags"
                         :filter="chargesFilter"
+                        @charge-created="onChargeCreated"
                         @charge-updated="onChargeUpdated"
                         @charge-deleted="onChargeDeleted"
                         @charges-moved="onChargesMoved"

--- a/src/views/__tests__/WalletView.spec.ts
+++ b/src/views/__tests__/WalletView.spec.ts
@@ -75,12 +75,15 @@ const makeGlobal = (walletID = '1') => ({
         stubs: {
             WalletsActiveShortList: { template: '<div />' },
             WalletHeader: { template: '<div />', props: ['wallet', 'totals', 'users'] },
-            ChargeCreate: { template: '<div />', props: ['wallet', 'walletTags'] },
-            ChargesList: { template: '<div />', props: ['wallet', 'walletTags', 'filter'] },
+            ChargesList: { name: 'ChargesList', template: '<div />', props: ['wallet', 'walletTags', 'filter'] },
             ChargesFilter: { template: '<div />' },
             ChargesFlowChart: { template: '<div />', props: ['walletId', 'currency', 'tags', 'dateFrom', 'dateTo'] },
             ChargesTotalChart: { template: '<div />', props: ['walletId', 'currency', 'walletTags', 'tags', 'dateFrom', 'dateTo'] },
-            WalletLimitsTotal: { template: '<div />', props: ['wallet'] },
+            WalletLimitsTotal: {
+                template: '<div />',
+                props: ['wallet'],
+                methods: { reload: () => {} },
+            },
             MoneyAmount: { template: '<span />', props: ['amount', 'currency'] },
             TagChip: { template: '<span />', props: ['tag', 'highlighted', 'removable'] },
             Tag: { template: '<span />', props: ['tag', 'highlighted', 'removable'] },
@@ -130,14 +133,12 @@ describe('WalletView.vue', () => {
 
         // Open all panels
         const vm = wrapper.vm as unknown as {
-            showCreateForm: boolean
             showFilters: boolean
             showGraph: boolean
             showLimits: boolean
             showTags: boolean
             wallet: Wallet | null
         }
-        vm.showCreateForm = true
         vm.showFilters = true
         vm.showGraph = true
         vm.showLimits = true
@@ -150,7 +151,6 @@ describe('WalletView.vue', () => {
         await wrapper.setProps({ walletID: '2' })
         await flushAll()
 
-        expect(vm.showCreateForm).toBe(false)
         expect(vm.showFilters).toBe(false)
         expect(vm.showGraph).toBe(false)
         expect(vm.showLimits).toBe(false)
@@ -206,85 +206,31 @@ describe('WalletView.vue', () => {
         expect(vm.error).toBeNull()
     })
 
-    describe('charge title autocomplete overflow override (issue #110)', () => {
-        // WalletView.vue's <UCollapsible> tags resolve at runtime to the global
-        // stub keyed 'Collapsible' (not 'UCollapsible') — verified empirically:
-        // matching against the 'UCollapsible' stub (by name or by reference)
-        // finds nothing, while the 'Collapsible' stub reference finds all 5.
-        function findCreateFormCollapsible(
-            wrapper: ReturnType<typeof mount>,
-            options: ReturnType<typeof makeGlobal>,
-        ) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const chargeCreate = wrapper.findComponent(options.global.stubs.ChargeCreate as any)
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const collapsibles = wrapper.findAllComponents(options.global.stubs.Collapsible as any)
-            const createCollapsible = collapsibles.find(c => c.element.contains(chargeCreate.element))
-            return { chargeCreate, createCollapsible, allCollapsibles: collapsibles }
-        }
+    // The create-charge entry point moved into ChargesList (issue #111) —
+    // see ChargesList.spec.ts for the create-row behaviour.
+    it('does not render its own New Charge toolbar button or ChargeCreate form (moved into ChargesList)', async () => {
+        const wrapper = mount(WalletView, makeGlobal())
+        await flushAll()
 
-        it("sets titleAutocompleteOpen from ChargeCreate's relayed dropdown-open-change and binds only the create-form UCollapsible's :ui override", async () => {
-            const options = makeGlobal()
-            const wrapper = mount(WalletView, options)
-            await flushAll()
+        expect(wrapper.findComponent({ name: 'ChargeCreate' }).exists()).toBe(false)
 
-            const vm = wrapper.vm as unknown as { showCreateForm: boolean; titleAutocompleteOpen: boolean }
-            vm.showCreateForm = true
-            await nextTick()
+        // Tool buttons render as real <button> elements via the UButton stub.
+        // Tags, Limits, Graph, Filters remain — no fifth "New Charge" button.
+        expect(wrapper.findAll('button').length).toBe(4)
+    })
 
-            const { chargeCreate, createCollapsible, allCollapsibles } = findCreateFormCollapsible(wrapper, options)
-            expect(chargeCreate.exists()).toBe(true)
-            expect(createCollapsible).toBeTruthy()
+    it('relays ChargesList\'s charge-created event into a totals/charts/limits/wallets-store refresh', async () => {
+        const wrapper = mount(WalletView, makeGlobal())
+        await flushAll()
 
-            // Closed by default: falls back to the theme's default (no override).
-            expect(vm.titleAutocompleteOpen).toBe(false)
-            expect(createCollapsible!.props('ui')).toEqual({ content: '' })
+        const callsBeforeCreate = vi.mocked(getWalletTotals).mock.calls.length
 
-            // The other UCollapsible instances (limits, tags, graph, filters) must never
-            // receive an overflow override — only the one wrapping ChargeCreate does.
-            expect(allCollapsibles.length).toBeGreaterThan(1)
-            const untouched = allCollapsibles.filter(c => c.element !== createCollapsible!.element)
-            expect(untouched.length).toBe(allCollapsibles.length - 1)
-            for (const c of untouched) {
-                expect(c.props('ui')).toBeUndefined()
-            }
+        const chargesList = wrapper.findComponent({ name: 'ChargesList' })
+        expect(chargesList.exists()).toBe(true)
+        await chargesList.vm.$emit('charge-created')
+        await flushAll()
 
-            chargeCreate.vm.$emit('dropdown-open-change', true)
-            await nextTick()
-            expect(vm.titleAutocompleteOpen).toBe(true)
-            expect(createCollapsible!.props('ui')).toEqual({ content: 'overflow-visible' })
-
-            chargeCreate.vm.$emit('dropdown-open-change', false)
-            await nextTick()
-            expect(vm.titleAutocompleteOpen).toBe(false)
-            expect(createCollapsible!.props('ui')).toEqual({ content: '' })
-        })
-
-        it('resets titleAutocompleteOpen when the create form closes, even if the dropdown never explicitly emitted false', async () => {
-            // Regression guard for a race: ChargeTitleFormInput's own blur timeout and
-            // the collapsible's exit-animation-driven unmount both fire around 200ms.
-            // If the unmount wins, the child is torn down before its watcher ever emits
-            // the final `false`. WalletView must not depend on receiving that event —
-            // closing the form has to deterministically reset the flag on its own.
-            const options = makeGlobal()
-            const wrapper = mount(WalletView, options)
-            await flushAll()
-
-            const vm = wrapper.vm as unknown as { showCreateForm: boolean; titleAutocompleteOpen: boolean }
-            vm.showCreateForm = true
-            await nextTick()
-
-            const { chargeCreate } = findCreateFormCollapsible(wrapper, options)
-            chargeCreate.vm.$emit('dropdown-open-change', true)
-            await nextTick()
-            expect(vm.titleAutocompleteOpen).toBe(true)
-
-            // Close the form without any further dropdown-open-change event.
-            vm.showCreateForm = false
-            await nextTick()
-
-            expect(vm.titleAutocompleteOpen).toBe(false)
-        })
+        expect(vi.mocked(getWalletTotals).mock.calls.length).toBe(callsBeforeCreate + 1)
     })
 
     it('clears wallet on switch-to-failing wallet', async () => {


### PR DESCRIPTION
Closes #111.

## What changed

The "New Charge" toolbar button in `WalletView` is gone. In its place, `ChargesList` renders a static top-level row at the head of the list:

- Carries a `+` icon on the timeline column, styled like a charge-type icon
- Always first, never part of a day group — it sits outside grouping, filtering, and pagination
- Clicking it expands `ChargeCreate` inline in the same layout, with the historical border running down the row's full height

## Details

- `ChargesList` now owns `isCreateOpen` and the create row. `WalletView` no longer renders its own button or `UCollapsible` for `ChargeCreate`, and `onChargeCreated` there is reduced to refreshing totals, charts, and limits.
- The create row lives outside the loading wrapper, so it stays clickable and unblurred while charges reload (wallet switch, filter change, initial fetch).
- The button stays visible while the form is open and toggles it shut, rather than being replaced by the form.
- Group headers draw a timeline connector behind the select-group control, so the vertical line reads as unbroken until that control appears on hover or selection. Inactive wallets keep their decorative horizontal dash and get no connector, avoiding a `+`-shaped overlap.
- Negative margins cancelling row padding carry matching breakpoints throughout, per #108.

## Verification

- Unit: 89 files / 789 tests pass, including a new `static create row (issue #111)` suite and a group-header connector test
- `type-check` clean; `lint` 0 errors
- E2E: desktop charges tier 28/28, mobile 10/10. `charges-move.spec.ts` needed a selector fix — the create row shares `ChargeItem`'s `.group.flex.items-stretch` fingerprint, so charge rows are now filtered by the absence of the `aria-hidden` icon button.

Note: `IT-04` and `NAV-07` fail on the full desktop suite with a strict-mode violation on the theme menu (`menuitemcheckbox` name `/Dark|Темна/i` resolves to 2 elements). Reproduced on a clean `master` baseline — pre-existing and out of scope here.
