### PR TITLE
feat(frontend): redesign limit tag picker for AND/OR group combinations

### DIFF
--- a/e2e/support/factories.ts
+++ b/e2e/support/factories.ts
@@ -157,7 +157,7 @@ export interface SeededLimit {
 }
 
 /**
- * Create a wallet limit. The API rejects an empty `tags` array (422) — a limit
+ * Create a wallet limit. The API rejects an empty `tagGroups` array (422) — a limit
  * must reference ≥1 tag, so seed one with createTagViaApi and pass its id.
  */
 export async function createLimitViaApi(
@@ -169,7 +169,7 @@ export async function createLimitViaApi(
     const data = await send(request, 'post', `/api/wallets/${walletId}/limits`, {
         type: opts.type ?? '-',
         amount: opts.amount ?? 100,
-        tags: [tagId],
+        tagGroups: [{ operation: 'or', tags: [tagId] }],
     })
     return { id: data.id as number, amount: data.amount as number }
 }

--- a/src/api/__tests__/limits.spec.ts
+++ b/src/api/__tests__/limits.spec.ts
@@ -16,7 +16,7 @@ import { Limit, WalletLimit } from '../models/limit'
 const rawLimit = {
     id: 10, operation: '-', amount: 500, walletId: 2,
     createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z',
-    tags: [], wallet: null,
+    tagGroups: [], wallet: null,
 }
 
 const rawWalletLimit = { amount: 200, percentage: 0.4, limit: rawLimit }
@@ -45,10 +45,16 @@ describe('createLimit', () => {
     it('posts limit data to /api/wallets/{id}/limits and returns Limit', async () => {
         mockAxios.post = vi.fn().mockResolvedValue({ data: { data: rawLimit } })
 
-        const result = await createLimit(2, { type: '-', amount: 500, tags: [1, 2] })
+        const result = await createLimit(2, {
+            type: '-',
+            amount: 500,
+            tagGroups: [{ operation: 'or', tags: [1] }, { operation: 'and', tags: [2, 3] }],
+        })
 
         expect(mockAxios.post).toHaveBeenCalledWith('/api/wallets/2/limits', {
-            type: '-', amount: 500, tags: [1, 2],
+            type: '-',
+            amount: 500,
+            tagGroups: [{ operation: 'or', tags: [1] }, { operation: 'and', tags: [2, 3] }],
         })
         expect(result).toBeInstanceOf(Limit)
         expect(result.amount).toBe(500)
@@ -63,10 +69,10 @@ describe('updateLimit', () => {
         const updated = { ...rawLimit, amount: 750 }
         mockAxios.put = vi.fn().mockResolvedValue({ data: { data: updated } })
 
-        const result = await updateLimit(2, 10, { type: '-', amount: 750, tags: [] })
+        const result = await updateLimit(2, 10, { type: '-', amount: 750, tagGroups: [] })
 
         expect(mockAxios.put).toHaveBeenCalledWith('/api/wallets/2/limits/10', {
-            type: '-', amount: 750, tags: [],
+            type: '-', amount: 750, tagGroups: [],
         })
         expect(result).toBeInstanceOf(Limit)
         expect(result.amount).toBe(750)

--- a/src/api/limits.ts
+++ b/src/api/limits.ts
@@ -4,7 +4,7 @@ import { Limit, WalletLimit } from './models/limit'
 export interface LimitRequest {
     type: '+' | '-'
     amount: number
-    tags: number[]
+    tagGroups: { operation: 'and' | 'or'; tags: number[] }[]
 }
 
 export async function getLimits(walletId: number): Promise<WalletLimit[]> {
@@ -19,7 +19,7 @@ export async function createLimit(walletId: number, request: LimitRequest): Prom
         const res = await client.post(`/api/wallets/${walletId}/limits`, {
             type: request.type,
             amount: request.amount,
-            tags: request.tags,
+            tagGroups: request.tagGroups,
         })
         return Limit.from(res.data.data)
     })
@@ -30,7 +30,7 @@ export async function updateLimit(walletId: number, limitId: number, request: Li
         const res = await client.put(`/api/wallets/${walletId}/limits/${limitId}`, {
             type: request.type,
             amount: request.amount,
-            tags: request.tags,
+            tagGroups: request.tagGroups,
         })
         return Limit.from(res.data.data)
     })

--- a/src/api/models/__tests__/limit.spec.ts
+++ b/src/api/models/__tests__/limit.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { Limit, WalletLimit } from '../limit'
+import { Limit, LimitTagGroup, WalletLimit } from '../limit'
 
 const walletShortRaw = {
     id: 10, name: 'My Wallet', slug: 'my-wallet', totalAmount: 1500,
@@ -13,6 +13,13 @@ const tagRaw = {
     userId: 1, createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z',
 }
 
+const tagRaw2 = {
+    id: 2, name: 'fuel', icon: null, color: null,
+    userId: 1, createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z',
+}
+
+const tagGroupRaw = { connection: 'or', tags: [tagRaw] }
+
 const limitRaw = {
     id: 5,
     operation: '-',
@@ -20,9 +27,37 @@ const limitRaw = {
     walletId: 10,
     createdAt: '2024-01-01T00:00:00Z',
     updatedAt: '2024-01-01T00:00:00Z',
-    tags: [tagRaw],
+    tagGroups: [tagGroupRaw],
     wallet: walletShortRaw,
 }
+
+describe('LimitTagGroup.from', () => {
+    it('parses connection and tags', () => {
+        const g = LimitTagGroup.from({ connection: 'and', tags: [tagRaw, tagRaw2] })
+        expect(g.connection).toBe('and')
+        expect(g.tags).toHaveLength(2)
+        expect(g.tags[0]).toEqual(expect.objectContaining({ id: 1 }))
+    })
+
+    it('parses or connection with a single tag', () => {
+        const g = LimitTagGroup.from(tagGroupRaw)
+        expect(g.connection).toBe('or')
+        expect(g.tags).toHaveLength(1)
+    })
+
+    it('defaults tags to empty array when missing', () => {
+        const g = LimitTagGroup.from({ connection: 'or' })
+        expect(g.tags).toEqual([])
+    })
+
+    it('throws on invalid connection', () => {
+        expect(() => LimitTagGroup.from({ connection: 'xor', tags: [] })).toThrow('invalid connection')
+    })
+
+    it('throws on non-object', () => {
+        expect(() => LimitTagGroup.from(null)).toThrow('expected object')
+    })
+})
 
 describe('Limit.from', () => {
     it('parses all fields', () => {
@@ -30,9 +65,27 @@ describe('Limit.from', () => {
         expect(l.id).toBe(5)
         expect(l.operation).toBe('-')
         expect(l.amount).toBe(500)
-        expect(l.tags).toHaveLength(1)
+        expect(l.tagGroups).toHaveLength(1)
+        expect(l.tagGroups[0]).toBeInstanceOf(LimitTagGroup)
+        expect(l.tagGroups[0].connection).toBe('or')
+        expect(l.tagGroups[0].tags).toHaveLength(1)
         expect(l.wallet?.id).toBe(10)
         expect(l.createdAt).toBeInstanceOf(Date)
+    })
+
+    it('parses multiple tag groups with mixed connections', () => {
+        const l = Limit.from({
+            ...limitRaw,
+            tagGroups: [{ connection: 'or', tags: [tagRaw] }, { connection: 'and', tags: [tagRaw2, tagRaw] }],
+        })
+        expect(l.tagGroups).toHaveLength(2)
+        expect(l.tagGroups[1].connection).toBe('and')
+        expect(l.tagGroups[1].tags).toHaveLength(2)
+    })
+
+    it('defaults tagGroups to empty array when missing', () => {
+        const l = Limit.from({ ...limitRaw, tagGroups: undefined })
+        expect(l.tagGroups).toEqual([])
     })
 
     it('parses + operation', () => {

--- a/src/api/models/limit.ts
+++ b/src/api/models/limit.ts
@@ -2,6 +2,33 @@ import { requireNumber, requireString } from './_validators'
 import { Tag } from './tag'
 import { WalletShort } from './wallet'
 
+export class LimitTagGroup {
+    readonly connection: 'and' | 'or'
+    readonly tags: Tag[]
+
+    constructor(data: { connection: 'and' | 'or'; tags: Tag[] }) {
+        this.connection = data.connection
+        this.tags = data.tags
+    }
+
+    static from(raw: unknown): LimitTagGroup {
+        if (!raw || typeof raw !== 'object') {
+            throw new Error('LimitTagGroup.from: expected object')
+        }
+        const d = raw as Record<string, unknown>
+
+        const connection = requireString(d, 'connection')
+        if (connection !== 'and' && connection !== 'or') {
+            throw new Error(`LimitTagGroup.from: invalid connection "${connection}"`)
+        }
+
+        return new LimitTagGroup({
+            connection,
+            tags: Array.isArray(d.tags) ? d.tags.map(Tag.from) : [],
+        })
+    }
+}
+
 export class Limit {
     readonly id: number
     readonly operation: '+' | '-'
@@ -9,7 +36,7 @@ export class Limit {
     readonly walletId: number
     readonly createdAt: Date
     readonly updatedAt: Date
-    readonly tags: Tag[]
+    readonly tagGroups: LimitTagGroup[]
     readonly wallet: WalletShort | null
 
     constructor(data: {
@@ -19,7 +46,7 @@ export class Limit {
         walletId: number
         createdAt: Date
         updatedAt: Date
-        tags: Tag[]
+        tagGroups: LimitTagGroup[]
         wallet: WalletShort | null
     }) {
         this.id = data.id
@@ -28,7 +55,7 @@ export class Limit {
         this.walletId = data.walletId
         this.createdAt = data.createdAt
         this.updatedAt = data.updatedAt
-        this.tags = data.tags
+        this.tagGroups = data.tagGroups
         this.wallet = data.wallet
     }
 
@@ -50,7 +77,7 @@ export class Limit {
             walletId: requireNumber(d, 'walletId'),
             createdAt: new Date(requireString(d, 'createdAt')),
             updatedAt: new Date(requireString(d, 'updatedAt')),
-            tags: Array.isArray(d.tags) ? d.tags.map(Tag.from) : [],
+            tagGroups: Array.isArray(d.tagGroups) ? d.tagGroups.map(LimitTagGroup.from) : [],
             wallet: d.wallet ? WalletShort.from(d.wallet) : null,
         })
     }

--- a/src/components/wallets/limits/LimitForm.vue
+++ b/src/components/wallets/limits/LimitForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { createLimit, updateLimit } from '@/api/limits'
 import type { Limit } from '@/api/models/limit'
@@ -9,6 +9,11 @@ import { useApiErrors } from '@/composables/useApiErrors'
 import TagFormInput from '@/components/tags/TagFormInput.vue'
 import TagChip from '@/components/tags/Tag.vue'
 import LoadErrorAlert from '@/components/Shared/LoadErrorAlert.vue'
+
+interface TagGroup {
+    connection: 'and' | 'or'
+    tags: Tag[]
+}
 
 const props = defineProps<{
     wallet: Wallet
@@ -23,7 +28,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const { fieldErrors, generalError, generalErrorRaw, reset: resetErrors, handleError } = useApiErrors([
-    'tags',
+    'tagGroups',
     'amount',
     'type',
 ])
@@ -32,13 +37,26 @@ const tagInputRef = ref<InstanceType<typeof TagFormInput> | null>(null)
 const loading = ref(false)
 const operation = ref<'+' | '-'>('-')
 const amount = ref<number | null>(null)
-const selectedTags = ref<Tag[]>([])
+// Tags selected for this limit, grouped by how they combine: tags within a group are ANDed
+// together, groups are ORed together. A group is 'and' iff it grew past one tag via an
+// AND-toggled pick; a lone tag (or the initial state) is always 'or'.
+const groups = ref<TagGroup[]>([])
+const nextConnection = ref<'and' | 'or'>('or')
+
+const selectedTags = computed(() => groups.value.flatMap(group => group.tags))
+
+const nextConnectionLabel = computed(() =>
+    nextConnection.value === 'and' ? t('limits.connectionAnd') : t('limits.connectionOr'),
+)
 
 function loadFromEdit() {
     if (props.edit) {
         operation.value = props.edit.operation
         amount.value = props.edit.amount
-        selectedTags.value = [...props.edit.tags]
+        groups.value = props.edit.tagGroups.map(group => ({
+            connection: group.connection,
+            tags: [...group.tags],
+        }))
     }
 }
 
@@ -46,11 +64,30 @@ onMounted(() => loadFromEdit())
 
 function onTagSelected(tag: Tag) {
     if (selectedTags.value.some(t => t.id === tag.id)) return
-    selectedTags.value = [tag, ...selectedTags.value]
+
+    if (nextConnection.value === 'and' && groups.value.length > 0) {
+        const lastIndex = groups.value.length - 1
+        groups.value = groups.value.map((group, index) =>
+            index === lastIndex
+                ? { connection: 'and' as const, tags: [...group.tags, tag] }
+                : group,
+        )
+    } else {
+        groups.value = [...groups.value, { connection: 'or' as const, tags: [tag] }]
+    }
 }
 
 function onTagRemoved(tag: Tag) {
-    selectedTags.value = selectedTags.value.filter(t => t.id !== tag.id)
+    groups.value = groups.value
+        .map(group => {
+            const tags = group.tags.filter(t => t.id !== tag.id)
+            return { connection: tags.length >= 2 ? group.connection : ('or' as const), tags }
+        })
+        .filter(group => group.tags.length > 0)
+}
+
+function toggleConnection() {
+    nextConnection.value = nextConnection.value === 'and' ? 'or' : 'and'
 }
 
 async function onSubmit() {
@@ -60,7 +97,10 @@ async function onSubmit() {
     const request = {
         type: operation.value,
         amount: Number(amount.value),
-        tags: selectedTags.value.map(t => t.id),
+        tagGroups: groups.value.map(group => ({
+            operation: group.connection,
+            tags: group.tags.map(t => t.id),
+        })),
     }
 
     try {
@@ -82,7 +122,8 @@ async function onSubmit() {
 function resetForm() {
     operation.value = '-'
     amount.value = null
-    selectedTags.value = []
+    groups.value = []
+    nextConnection.value = 'or'
     tagInputRef.value?.reset()
 }
 
@@ -94,29 +135,45 @@ function onCancel() {
 
 <template>
     <form @submit.prevent="onSubmit" class="space-y-3">
-        <!-- Selected tags -->
-        <div v-if="selectedTags.length > 0" class="flex flex-wrap gap-1">
-            <TagChip
-                v-for="tag in selectedTags"
-                :key="tag.id"
-                :tag="tag"
-                removable
-                @click="onTagRemoved(tag)"
-            />
+        <!-- Selected tags, grouped: tags within a group sit close together, a "+" label
+             (with extra spacing) separates distinct groups -->
+        <div v-if="groups.length > 0" class="flex flex-wrap items-center gap-1">
+            <template v-for="(group, groupIndex) in groups" :key="groupIndex">
+                <span v-if="groupIndex > 0" class="mx-2 text-xs text-muted select-none">+</span>
+                <TagChip
+                    v-for="tag in group.tags"
+                    :key="tag.id"
+                    :tag="tag"
+                    removable
+                    @click="onTagRemoved(tag)"
+                />
+            </template>
         </div>
 
         <!-- Tag search + Operation toggle + Amount -->
         <!-- Mobile: stacked, full width (Type+Amount on top, Tag below). Desktop: one row,
              Tag left (3/5) + Type+Amount right (2/5). flex order swaps the visual order. -->
         <div class="flex flex-col sm:flex-row gap-2">
-            <UFormField class="w-full sm:w-3/5 order-2 sm:order-1" :error="fieldErrors.tags?.[0]">
-                <TagFormInput
-                    ref="tagInputRef"
-                    :wallet-id="wallet.id"
-                    :tags="selectedTags"
-                    :disabled="loading"
-                    @selected="onTagSelected"
-                />
+            <UFormField class="w-full sm:w-3/5 order-2 sm:order-1" :error="fieldErrors.tagGroups?.[0]">
+                <UFieldGroup size="lg" class="w-full">
+                    <TagFormInput
+                        ref="tagInputRef"
+                        class="flex-1"
+                        :wallet-id="wallet.id"
+                        :tags="selectedTags"
+                        :disabled="loading"
+                        @selected="onTagSelected"
+                    />
+                    <UTooltip :text="t('limits.connectionToggleTooltip')" :arrow="true">
+                        <UButton
+                            :label="nextConnectionLabel"
+                            :color="nextConnection === 'and' ? 'primary' : 'neutral'"
+                            variant="soft"
+                            :disabled="loading"
+                            @click="toggleConnection"
+                        />
+                    </UTooltip>
+                </UFieldGroup>
             </UFormField>
 
             <div class="flex items-start gap-0 w-full sm:w-2/5 order-1 sm:order-2">

--- a/src/components/wallets/limits/WalletLimitItem.vue
+++ b/src/components/wallets/limits/WalletLimitItem.vue
@@ -80,11 +80,14 @@ function onEditCancelled() {
                     name="i-lucide-arrow-down"
                     class="text-red-500 hidden sm:inline-block size-6"
                 />
-                <Tag
-                    v-for="tag in walletLimit.limit.tags"
-                    :key="tag.id"
-                    :tag="tag"
-                />
+                <template v-for="(group, groupIndex) in walletLimit.limit.tagGroups" :key="groupIndex">
+                    <span v-if="groupIndex > 0" class="mx-2 text-xs text-muted select-none">+</span>
+                    <Tag
+                        v-for="tag in group.tags"
+                        :key="tag.id"
+                        :tag="tag"
+                    />
+                </template>
             </div>
             <div class="flex items-center gap-2 justify-between sm:justify-normal">
                 <span class="text-lg whitespace-nowrap" :class="isIncome ? 'text-primary' : 'text-red-500'">

--- a/src/components/wallets/limits/__tests__/LimitForm.spec.ts
+++ b/src/components/wallets/limits/__tests__/LimitForm.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ref } from 'vue'
-import { shallowMount } from '@vue/test-utils'
+import { shallowMount, mount } from '@vue/test-utils'
 import { AxiosError } from 'axios'
 import { Wallet } from '@/api/models/wallet'
 import { Currency } from '@/api/models/currency'
@@ -23,6 +23,10 @@ const mockUpdateLimit = vi.fn()
 vi.mock('@/api/limits', () => ({
     createLimit: (...args: unknown[]) => mockCreateLimit(...args),
     updateLimit: (...args: unknown[]) => mockUpdateLimit(...args),
+}))
+vi.mock('@/api/tags', () => ({
+    getWalletTags: vi.fn().mockResolvedValue([]),
+    searchWalletTags: vi.fn().mockResolvedValue([]),
 }))
 
 const usd = new Currency({
@@ -169,6 +173,22 @@ describe('LimitForm', () => {
         expect(vm.groups[0].tags.map(t => t.id)).toEqual([1, 2])
     })
 
+    it('toggling the connection flips nextConnection and its label between OR and AND', () => {
+        const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet() } })
+        const vm = wrapper.vm as unknown as LimitFormVm & { nextConnectionLabel: string }
+
+        expect(vm.nextConnection).toBe('or')
+        expect(vm.nextConnectionLabel).toBe('limits.connectionOr')
+
+        vm.toggleConnection()
+        expect(vm.nextConnection).toBe('and')
+        expect(vm.nextConnectionLabel).toBe('limits.connectionAnd')
+
+        vm.toggleConnection()
+        expect(vm.nextConnection).toBe('or')
+        expect(vm.nextConnectionLabel).toBe('limits.connectionOr')
+    })
+
     it('does not add a duplicate tag id across groups', () => {
         const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet() } })
         const vm = wrapper.vm as unknown as LimitFormVm
@@ -211,6 +231,25 @@ describe('LimitForm', () => {
         expect(vm.groups).toHaveLength(1)
         expect(vm.groups[0].connection).toBe('or')
         expect(vm.groups[0].tags).toEqual([fuel])
+    })
+
+    it('removing one tag from a 3-tag AND group keeps the connection as AND', () => {
+        const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet() } })
+        const vm = wrapper.vm as unknown as LimitFormVm
+        const fuel = makeTag(1, 'Fuel')
+        const medicine = makeTag(2, 'Medicine')
+        const parking = makeTag(3, 'Parking')
+        vm.onTagSelected(fuel)
+        vm.toggleConnection()
+        vm.onTagSelected(medicine)
+        vm.onTagSelected(parking)
+        expect(vm.groups[0].tags).toHaveLength(3)
+
+        vm.onTagRemoved(medicine)
+
+        expect(vm.groups).toHaveLength(1)
+        expect(vm.groups[0].connection).toBe('and')
+        expect(vm.groups[0].tags.map(t => t.id)).toEqual([1, 3])
     })
 
     it('calls createLimit with the entered amount, operation and tag groups on submit', async () => {
@@ -265,6 +304,30 @@ describe('LimitForm', () => {
         expect(vm.groups).toHaveLength(0)
     })
 
+    it("resets the tag input's own state after a successful create", async () => {
+        const limit = makeLimit()
+        mockCreateLimit.mockResolvedValue(limit)
+
+        // Deep mount: TagFormInput sits inside UFormField/UFieldGroup, which shallowMount
+        // would auto-stub without rendering their slot content, leaving tagInputRef null.
+        // Tooltip is stubbed because it requires a TooltipProvider ancestor not present here.
+        const wrapper = mount(LimitForm, {
+            props: { wallet: makeWallet() },
+            global: { stubs: { Tooltip: true } },
+        })
+        const vm = wrapper.vm as unknown as LimitFormVm & { tagInputRef: { reset: () => void } }
+        const resetSpy = vi.spyOn(vm.tagInputRef, 'reset')
+        vm.amount = 100
+        vm.onTagSelected(makeTag())
+
+        await wrapper.find('form').trigger('submit')
+
+        await vi.waitFor(() => {
+            expect(wrapper.emitted('created')).toBeTruthy()
+        })
+        expect(resetSpy).toHaveBeenCalledTimes(1)
+    })
+
     it('calls updateLimit and emits updated in edit mode (form is not reset)', async () => {
         const limit = makeLimit({ id: 7 })
         const updated = makeLimit({ id: 7, amount: 999 })
@@ -295,6 +358,26 @@ describe('LimitForm', () => {
         const alert = wrapper.findComponent({ name: 'LoadErrorAlert' })
         expect(alert.props('retryable')).toBeFalsy()
         expect(wrapper.findComponent({ name: 'UAlert' }).exists()).toBe(false)
+    })
+
+    it('falls back to the default unknown-error title if generalError is unexpectedly unset', async () => {
+        mockCreateLimit.mockRejectedValue(new Error('network error'))
+
+        const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet() } })
+        const vm = wrapper.vm as unknown as LimitFormVm
+        vm.amount = 100
+
+        await wrapper.find('form').trigger('submit')
+
+        await vi.waitFor(() => {
+            expect(wrapper.findComponent({ name: 'LoadErrorAlert' }).exists()).toBe(true)
+        })
+
+        vm.generalError = null
+        await wrapper.vm.$nextTick()
+
+        const alert = wrapper.findComponent({ name: 'LoadErrorAlert' })
+        expect(alert.props('title')).toBe('unknownError')
     })
 
     it('routes a 422 error for a field the form does not render into generalError, not LoadErrorAlert', async () => {
@@ -340,6 +423,52 @@ describe('LimitForm', () => {
 
         await vi.waitFor(() => {
             expect(vm.fieldErrors.tagGroups?.[0]).toBe('At least one tag is required')
+        })
+        expect(vm.generalError).toBeNull()
+    })
+
+    it('routes a 422 error for the amount field into fieldErrors', async () => {
+        const axiosError = new AxiosError('Validation failed')
+        axiosError.response = {
+            status: 422,
+            data: { errors: { amount: ['Amount must be greater than 0'] } },
+            headers: {},
+            config: {} as never,
+            statusText: 'Unprocessable Entity',
+        }
+        mockCreateLimit.mockRejectedValue(axiosError)
+
+        const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet() } })
+        const vm = wrapper.vm as unknown as LimitFormVm
+        vm.amount = 100
+
+        await wrapper.find('form').trigger('submit')
+
+        await vi.waitFor(() => {
+            expect(vm.fieldErrors.amount?.[0]).toBe('Amount must be greater than 0')
+        })
+        expect(vm.generalError).toBeNull()
+    })
+
+    it('routes a 422 error for the type field into fieldErrors', async () => {
+        const axiosError = new AxiosError('Validation failed')
+        axiosError.response = {
+            status: 422,
+            data: { errors: { type: ['Type is invalid'] } },
+            headers: {},
+            config: {} as never,
+            statusText: 'Unprocessable Entity',
+        }
+        mockCreateLimit.mockRejectedValue(axiosError)
+
+        const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet() } })
+        const vm = wrapper.vm as unknown as LimitFormVm
+        vm.amount = 100
+
+        await wrapper.find('form').trigger('submit')
+
+        await vi.waitFor(() => {
+            expect(vm.fieldErrors.type?.[0]).toBe('Type is invalid')
         })
         expect(vm.generalError).toBeNull()
     })

--- a/src/components/wallets/limits/__tests__/LimitForm.spec.ts
+++ b/src/components/wallets/limits/__tests__/LimitForm.spec.ts
@@ -4,7 +4,7 @@ import { shallowMount } from '@vue/test-utils'
 import { AxiosError } from 'axios'
 import { Wallet } from '@/api/models/wallet'
 import { Currency } from '@/api/models/currency'
-import { Limit } from '@/api/models/limit'
+import { Limit, LimitTagGroup } from '@/api/models/limit'
 import { Tag } from '@/api/models/tag'
 import LimitForm from '../LimitForm.vue'
 
@@ -59,7 +59,9 @@ function makeTag(id = 1, name = 'Food'): Tag {
     })
 }
 
-function makeLimit(overrides: Partial<{ id: number; operation: '+' | '-'; amount: number; tags: Tag[] }> = {}): Limit {
+type TagGroupInput = { connection: 'and' | 'or'; tags: Tag[] }
+
+function makeLimit(overrides: Partial<{ id: number; operation: '+' | '-'; amount: number; tagGroups: TagGroupInput[] }> = {}): Limit {
     return new Limit({
         id: overrides.id ?? 1,
         operation: overrides.operation ?? '-',
@@ -67,9 +69,22 @@ function makeLimit(overrides: Partial<{ id: number; operation: '+' | '-'; amount
         walletId: 1,
         createdAt: new Date(),
         updatedAt: new Date(),
-        tags: overrides.tags ?? [makeTag()],
+        tagGroups: (overrides.tagGroups ?? [{ connection: 'or', tags: [makeTag()] }]).map(g => new LimitTagGroup(g)),
         wallet: null,
     })
+}
+
+type LimitFormVm = {
+    operation: '+' | '-'
+    amount: number | null
+    groups: TagGroupInput[]
+    nextConnection: 'and' | 'or'
+    onTagSelected: (tag: Tag) => void
+    onTagRemoved: (tag: Tag) => void
+    toggleConnection: () => void
+    onCancel: () => void
+    fieldErrors: Record<string, string[]>
+    generalError: string | null
 }
 
 describe('LimitForm', () => {
@@ -80,36 +95,138 @@ describe('LimitForm', () => {
 
     it('defaults to a blank expense form when no edit prop is provided', () => {
         const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet() } })
-        const vm = wrapper.vm as unknown as { operation: '+' | '-'; amount: number | null; selectedTags: Tag[] }
+        const vm = wrapper.vm as unknown as LimitFormVm
         expect(vm.operation).toBe('-')
         expect(vm.amount).toBeNull()
-        expect(vm.selectedTags).toHaveLength(0)
+        expect(vm.groups).toHaveLength(0)
+        expect(vm.nextConnection).toBe('or')
         expect(wrapper.find('form').exists()).toBe(true)
     })
 
-    it('pre-fills operation, amount and tags from the edit prop', () => {
+    it('pre-fills operation, amount and tag groups from the edit prop', () => {
         const limit = makeLimit({ operation: '+', amount: 250 })
         const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet(), edit: limit } })
 
-        const vm = wrapper.vm as unknown as { operation: '+' | '-'; amount: number | null; selectedTags: Tag[] }
+        const vm = wrapper.vm as unknown as LimitFormVm
         expect(vm.operation).toBe('+')
         expect(vm.amount).toBe(250)
-        expect(vm.selectedTags).toHaveLength(1)
+        expect(vm.groups).toHaveLength(1)
+        expect(vm.groups[0].tags).toHaveLength(1)
     })
 
-    it('calls createLimit with the entered amount, operation and tags on submit', async () => {
-        const tag = makeTag()
-        mockCreateLimit.mockResolvedValue(makeLimit({ tags: [tag] }))
+    it('pre-fills multiple groups (OR + AND) from edit.tagGroups without aliasing the source tags', () => {
+        const shop = makeTag(1, 'Shop')
+        const fuel = makeTag(2, 'Fuel')
+        const medicine = makeTag(3, 'Medicine')
+        const limit = makeLimit({
+            tagGroups: [
+                { connection: 'or', tags: [shop] },
+                { connection: 'and', tags: [fuel, medicine] },
+            ],
+        })
+
+        const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet(), edit: limit } })
+        const vm = wrapper.vm as unknown as LimitFormVm
+
+        expect(vm.groups).toHaveLength(2)
+        expect(vm.groups[0]).toEqual({ connection: 'or', tags: [shop] })
+        expect(vm.groups[1].connection).toBe('and')
+        expect(vm.groups[1].tags.map(t => t.id)).toEqual([2, 3])
+
+        // form state must be a deep copy: mutating it must not affect the source Limit
+        vm.groups[0].tags.push(fuel)
+        expect(limit.tagGroups[0].tags).toHaveLength(1)
+    })
+
+    it('selecting tags under the default OR mode creates separate groups', () => {
+        const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet() } })
+        const vm = wrapper.vm as unknown as LimitFormVm
+        const shop = makeTag(1, 'Shop')
+        const coffee = makeTag(2, 'Coffee')
+
+        expect(vm.nextConnection).toBe('or')
+        vm.onTagSelected(shop)
+        vm.onTagSelected(coffee)
+
+        expect(vm.groups).toHaveLength(2)
+        expect(vm.groups[0]).toEqual({ connection: 'or', tags: [shop] })
+        expect(vm.groups[1]).toEqual({ connection: 'or', tags: [coffee] })
+    })
+
+    it('toggling to AND merges the next selected tag into the last group', () => {
+        const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet() } })
+        const vm = wrapper.vm as unknown as LimitFormVm
+        const fuel = makeTag(1, 'Fuel')
+        const medicine = makeTag(2, 'Medicine')
+
+        vm.onTagSelected(fuel)
+        vm.toggleConnection()
+        expect(vm.nextConnection).toBe('and')
+        vm.onTagSelected(medicine)
+
+        expect(vm.groups).toHaveLength(1)
+        expect(vm.groups[0].connection).toBe('and')
+        expect(vm.groups[0].tags.map(t => t.id)).toEqual([1, 2])
+    })
+
+    it('does not add a duplicate tag id across groups', () => {
+        const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet() } })
+        const vm = wrapper.vm as unknown as LimitFormVm
+        const shop = makeTag(1, 'Shop')
+
+        vm.onTagSelected(shop)
+        vm.onTagSelected(shop)
+
+        expect(vm.groups).toHaveLength(1)
+        expect(vm.groups[0].tags).toHaveLength(1)
+    })
+
+    it('removing the only tag in a group removes the group entirely', () => {
+        const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet() } })
+        const vm = wrapper.vm as unknown as LimitFormVm
+        const shop = makeTag(1, 'Shop')
+        const coffee = makeTag(2, 'Coffee')
+        vm.onTagSelected(shop)
+        vm.onTagSelected(coffee)
+        expect(vm.groups).toHaveLength(2)
+
+        vm.onTagRemoved(shop)
+
+        expect(vm.groups).toHaveLength(1)
+        expect(vm.groups[0].tags).toEqual([coffee])
+    })
+
+    it('removing one tag from an AND group demotes it back to a lone OR group', () => {
+        const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet() } })
+        const vm = wrapper.vm as unknown as LimitFormVm
+        const fuel = makeTag(1, 'Fuel')
+        const medicine = makeTag(2, 'Medicine')
+        vm.onTagSelected(fuel)
+        vm.toggleConnection()
+        vm.onTagSelected(medicine)
+        expect(vm.groups[0].connection).toBe('and')
+
+        vm.onTagRemoved(medicine)
+
+        expect(vm.groups).toHaveLength(1)
+        expect(vm.groups[0].connection).toBe('or')
+        expect(vm.groups[0].tags).toEqual([fuel])
+    })
+
+    it('calls createLimit with the entered amount, operation and tag groups on submit', async () => {
+        const shop = makeTag(1, 'Shop')
+        const fuel = makeTag(2, 'Fuel')
+        const medicine = makeTag(3, 'Medicine')
+        mockCreateLimit.mockResolvedValue(makeLimit())
 
         const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet() } })
-        const vm = wrapper.vm as unknown as {
-            amount: number | null
-            operation: '+' | '-'
-            selectedTags: Tag[]
-        }
+        const vm = wrapper.vm as unknown as LimitFormVm
         vm.amount = 100
         vm.operation = '-'
-        vm.selectedTags = [tag]
+        vm.onTagSelected(shop) // OR (default): starts group [Shop]
+        vm.onTagSelected(fuel) // still OR: starts a new group [Fuel]
+        vm.toggleConnection() // switch to AND before the next pick
+        vm.onTagSelected(medicine) // AND: merges into the last group -> [Fuel, Medicine]
 
         await wrapper.find('form').trigger('submit')
 
@@ -119,7 +236,14 @@ describe('LimitForm', () => {
 
         const [walletId, request] = mockCreateLimit.mock.calls[0]
         expect(walletId).toBe(1)
-        expect(request).toEqual({ type: '-', amount: 100, tags: [tag.id] })
+        expect(request).toEqual({
+            type: '-',
+            amount: 100,
+            tagGroups: [
+                { operation: 'or', tags: [shop.id] },
+                { operation: 'and', tags: [fuel.id, medicine.id] },
+            ],
+        })
     })
 
     it('emits created and resets the form after a successful create', async () => {
@@ -127,8 +251,9 @@ describe('LimitForm', () => {
         mockCreateLimit.mockResolvedValue(limit)
 
         const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet() } })
-        const vm = wrapper.vm as unknown as { amount: number | null }
+        const vm = wrapper.vm as unknown as LimitFormVm
         vm.amount = 100
+        vm.onTagSelected(makeTag())
 
         await wrapper.find('form').trigger('submit')
 
@@ -137,6 +262,7 @@ describe('LimitForm', () => {
         })
         expect(wrapper.emitted('created')![0]).toEqual([limit])
         expect(vm.amount).toBeNull()
+        expect(vm.groups).toHaveLength(0)
     })
 
     it('calls updateLimit and emits updated in edit mode (form is not reset)', async () => {
@@ -157,7 +283,7 @@ describe('LimitForm', () => {
         mockCreateLimit.mockRejectedValue(new Error('network error'))
 
         const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet() } })
-        const vm = wrapper.vm as unknown as { amount: number | null }
+        const vm = wrapper.vm as unknown as LimitFormVm
         vm.amount = 100
 
         await wrapper.find('form').trigger('submit')
@@ -183,11 +309,7 @@ describe('LimitForm', () => {
         mockCreateLimit.mockRejectedValue(axiosError)
 
         const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet() } })
-        const vm = wrapper.vm as unknown as {
-            amount: number | null
-            fieldErrors: Record<string, string[]>
-            generalError: string | null
-        }
+        const vm = wrapper.vm as unknown as LimitFormVm
         vm.amount = 100
 
         await wrapper.find('form').trigger('submit')
@@ -199,16 +321,38 @@ describe('LimitForm', () => {
         expect(wrapper.findComponent({ name: 'LoadErrorAlert' }).exists()).toBe(false)
     })
 
+    it('routes a 422 error for the tagGroups field into fieldErrors, not generalError', async () => {
+        const axiosError = new AxiosError('Validation failed')
+        axiosError.response = {
+            status: 422,
+            data: { errors: { tagGroups: ['At least one tag is required'] } },
+            headers: {},
+            config: {} as never,
+            statusText: 'Unprocessable Entity',
+        }
+        mockCreateLimit.mockRejectedValue(axiosError)
+
+        const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet() } })
+        const vm = wrapper.vm as unknown as LimitFormVm
+        vm.amount = 100
+
+        await wrapper.find('form').trigger('submit')
+
+        await vi.waitFor(() => {
+            expect(vm.fieldErrors.tagGroups?.[0]).toBe('At least one tag is required')
+        })
+        expect(vm.generalError).toBeNull()
+    })
+
     it('cancel resets the form and emits cancelled', async () => {
         const wrapper = shallowMount(LimitForm, { props: { wallet: makeWallet() } })
-        const vm = wrapper.vm as unknown as {
-            amount: number | null
-            onCancel: () => void
-        }
+        const vm = wrapper.vm as unknown as LimitFormVm
         vm.amount = 42
+        vm.onTagSelected(makeTag())
         vm.onCancel()
 
         expect(vm.amount).toBeNull()
+        expect(vm.groups).toHaveLength(0)
         expect(wrapper.emitted('cancelled')).toBeTruthy()
     })
 })

--- a/src/components/wallets/limits/__tests__/WalletLimitItem.spec.ts
+++ b/src/components/wallets/limits/__tests__/WalletLimitItem.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { ref } from 'vue'
 import { shallowMount } from '@vue/test-utils'
 import WalletLimitItem from '../WalletLimitItem.vue'
-import { WalletLimit, Limit } from '@/api/models/limit'
+import { WalletLimit, Limit, LimitTagGroup } from '@/api/models/limit'
 import { Wallet } from '@/api/models/wallet'
 import { Currency } from '@/api/models/currency'
 import { Tag } from '@/api/models/tag'
@@ -52,7 +52,7 @@ function makeWalletLimit(percentage: number): WalletLimit {
         limit: new Limit({
             id: 1, operation: '-', amount: 1000, walletId: 1,
             createdAt: new Date(), updatedAt: new Date(),
-            tags: [makeTag()], wallet: null,
+            tagGroups: [new LimitTagGroup({ connection: 'or', tags: [makeTag()] })], wallet: null,
         }),
     })
 }
@@ -133,5 +133,42 @@ describe('WalletLimitItem', () => {
         })
         expect(wrapper.find('.text-xs').text()).toBe('100%')
         expect(wrapper.find('.bg-red-500').exists()).toBe(true)
+    })
+
+    it('renders a "+" separator between tag groups but not within a group', () => {
+        const shop = makeTag()
+        const fuel = new Tag({ id: 2, name: 'Fuel', icon: null, color: '#00ff00', userId: 1, createdAt: new Date(), updatedAt: new Date() })
+        const medicine = new Tag({ id: 3, name: 'Medicine', icon: null, color: '#0000ff', userId: 1, createdAt: new Date(), updatedAt: new Date() })
+
+        const walletLimit = new WalletLimit({
+            amount: 500,
+            percentage: 50,
+            limit: new Limit({
+                id: 1, operation: '-', amount: 1000, walletId: 1,
+                createdAt: new Date(), updatedAt: new Date(),
+                tagGroups: [
+                    new LimitTagGroup({ connection: 'or', tags: [shop] }),
+                    new LimitTagGroup({ connection: 'and', tags: [fuel, medicine] }),
+                ],
+                wallet: null,
+            }),
+        })
+
+        const wrapper = shallowMount(WalletLimitItem, {
+            ...stubs,
+            props: { walletLimit, wallet: makeWallet() },
+        })
+
+        const separators = wrapper.findAll('span.mx-2')
+        expect(separators).toHaveLength(1)
+        expect(separators[0].text()).toBe('+')
+    })
+
+    it('renders no separator for a single tag group', () => {
+        const wrapper = shallowMount(WalletLimitItem, {
+            ...stubs,
+            props: { walletLimit: makeWalletLimit(50), wallet: makeWallet() },
+        })
+        expect(wrapper.findAll('span.mx-2')).toHaveLength(0)
     })
 })

--- a/src/components/wallets/limits/__tests__/WalletLimitsTotal.spec.ts
+++ b/src/components/wallets/limits/__tests__/WalletLimitsTotal.spec.ts
@@ -49,7 +49,7 @@ function makeWalletLimit(id = 1): WalletLimit {
         limit: new Limit({
             id, operation: '-', amount: 1000, walletId: 1,
             createdAt: new Date(), updatedAt: new Date(),
-            tags: [], wallet: null,
+            tagGroups: [], wallet: null,
         }),
     })
 }

--- a/src/lang/messages/en.ts
+++ b/src/lang/messages/en.ts
@@ -313,6 +313,10 @@ export default {
         deletingConfirm: 'Are you sure you want to delete this limit? This action cannot be undone.',
 
         total: 'Total',
+
+        connectionOr: 'OR',
+        connectionAnd: 'AND',
+        connectionToggleTooltip: 'Toggle how the next selected tag combines with the previous one',
     },
 
     titles: {

--- a/src/lang/messages/uk.ts
+++ b/src/lang/messages/uk.ts
@@ -313,6 +313,10 @@ export default {
         deletingConfirm: 'Точно видалити цей ліміт? Цю дію неможливо скасувати.',
 
         total: 'Всього',
+
+        connectionOr: 'АБО',
+        connectionAnd: 'І',
+        connectionToggleTooltip: 'Перемкнути, як наступний обраний тег поєднується з попереднім',
     },
 
     titles: {


### PR DESCRIPTION
## Problem

The limit form only supported a single flat list of tags (implicit AND), matching the old API shape. It couldn't express OR'd tag groups or mixed AND/OR combinations (issue #152).

## Changes

- `Limit.tags` replaced by `Limit.tagGroups: LimitTagGroup[]` (`{ connection: 'and' | 'or', tags: Tag[] }`) in the API model layer.
- `LimitForm.vue` reworked around a `groups` array: a connection toggle next to the tag input controls whether the next selected tag starts a new group (OR, default) or merges into the last group (AND).
- Selected tags render grouped, with a "+" separator between (not within) groups; `WalletLimitItem.vue`'s read-only display mirrors the same layout.
- Request payload now sends `tagGroups: [{ operation, tags: number[] }]` instead of `tags: number[]`.
- New i18n strings (`connectionOr`, `connectionAnd`, `connectionToggleTooltip`) added for EN and UK.
- `e2e/support/factories.ts` updated to POST the new `tagGroups` shape.

## Verification

- `npm run lint`: 0 errors (pre-existing unrelated Playwright warnings only)
- `npm run test:unit -- --run`: 89/89 files, 805/805 tests passing
- Manually tested against the running local stack (login → wallet → limits) — confirmed working

Note: no automated Playwright E2E run was performed for this change (no live stack in the automated verification pass); manual verification covered the golden path.