### PR TITLE
fix(wallets): match Limit form button size to Charge form

### DIFF
--- a/src/components/wallets/limits/LimitForm.vue
+++ b/src/components/wallets/limits/LimitForm.vue
@@ -225,7 +225,6 @@ function onCancel() {
             <UButton
                 type="submit"
                 color="primary"
-                size="lg"
                 :loading="loading"
             >
                 {{ edit ? t('limits.update') : t('limits.create') }}
@@ -233,7 +232,6 @@ function onCancel() {
             <UButton
                 variant="outline"
                 color="neutral"
-                size="lg"
                 :disabled="loading"
                 @click="onCancel"
             >


### PR DESCRIPTION
## Summary
- Remove the explicit `size="lg"` override on the Limit form's submit/cancel buttons so they match the default (`md`) size used by the Charge form's actions, per the generic design.

Fixes #154